### PR TITLE
⚙️ Kick out `@openreachtech:registry` from `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 min-release-age = 7
-
-@openreachtech:registry = https://npm.pkg.github.com


### PR DESCRIPTION
# Why

* Close #32