### PR TITLE
🔧 Restore the empty `dependencies` block in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "url": "https://github.com/openreachtech/hora-ecosystem/issues"
   },
   "homepage": "https://github.com/openreachtech/hora-ecosystem#readme",
+  "dependencies": {
+  },
   "devDependencies": {
     "@openreachtech/eslint-config": "^4.5.0",
     "@openreachtech/furo": "^1.10.1",


### PR DESCRIPTION
npm drops an empty `"dependencies": {}` block whenever it rewrites `package.json`, so the
block disappeared while re-resolving the packages in #50. npm-boilerplate keeps it, and this catalog
genuinely has no runtime dependency, so the empty block says so explicitly.

Close #53