### PR TITLE
📦️ Update `renchan` to `2.9.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@openreachtech/mentsu-validation-rules": "^1.0.2",
         "@openreachtech/mentsu-value-inspector": "^1.1.1",
         "@openreachtech/mentsu-value-normalizer": "^1.0.1",
-        "@openreachtech/renchan": "^2.9.1",
+        "@openreachtech/renchan": "^2.9.2",
         "@openreachtech/renchan-elasticsearch": "^1.9.1",
         "@openreachtech/renchan-env": "^1.0.5",
         "@openreachtech/renchan-funnel": "^1.1.2",
@@ -3933,15 +3933,16 @@
       }
     },
     "node_modules/@openreachtech/renchan": {
-      "version": "2.9.1",
-      "resolved": "https://npm.pkg.github.com/download/@openreachtech/renchan/2.9.1/5f0c7a87666fa50616e3a0fd80c8c89b88b8fd34",
-      "integrity": "sha512-RingUG8l/678EneFnxUtctdZc9PQl89fDXlklbcKoH1lKPLAYnuDiHgi9D54IV//1GB2eGwKz5nXOtwXeM/UtQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@openreachtech/renchan/-/renchan-2.9.2.tgz",
+      "integrity": "sha512-20inV0eJrIIS67a87b3MH0a+LILAsY9C5N6w+FcTdz2nH9y13JJ29BFNGFCyynKM27lgtCcN9rnr/5gRpwRXNA==",
       "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-tools/schema": "^10.0.6",
         "@graphql-tools/utils": "^10.5.5",
-        "@openreachtech/renchan-env": "^1.0.2",
+        "@openreachtech/renchan-env": "^1.0.5",
+        "bignumber.js": "^9.1.1",
         "cors": "^2.8.5",
         "express": "^4.21.1",
         "graphql": "^16.9.0",
@@ -3953,6 +3954,12 @@
         "ioredis": "^5.4.1",
         "multer": "^2.1.1",
         "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "sequelize": "^6.37.8"
       }
     },
     "node_modules/@openreachtech/renchan-elasticsearch": {
@@ -4053,6 +4060,16 @@
         "@openreachtech/mentsu-random-text-generator": "^1.0.0",
         "@openreachtech/renchan-env": "^1.0.4",
         "@steweucen/fertile-forest-sequelize": "^0.1.3"
+      }
+    },
+    "node_modules/@openreachtech/renchan/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@openreachtech/renchan/node_modules/graphql-ws": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openreachtech/mentsu-validation-rules": "^1.0.2",
     "@openreachtech/mentsu-value-inspector": "^1.1.1",
     "@openreachtech/mentsu-value-normalizer": "^1.0.1",
-    "@openreachtech/renchan": "^2.9.1",
+    "@openreachtech/renchan": "^2.9.2",
     "@openreachtech/renchan-elasticsearch": "^1.9.1",
     "@openreachtech/renchan-env": "^1.0.5",
     "@openreachtech/renchan-funnel": "^1.1.2",


### PR DESCRIPTION
`@openreachtech/renchan` 2.9.2 is published on npmjs, so it moves over from GitHub Packages
along with the Apache-2.0 relicense.

It was the last entry in `package-lock.json` still resolved from GitHub Packages:

```
grep -c npm.pkg.github.com package-lock.json
0
```

`npm install` no longer needs a GitHub Packages token. Removing `registry-url` and
`NODE_AUTH_TOKEN` from the test workflow follows separately.

Close #55