### PR TITLE
📄 Kick out the GitHub-Packages step from the documents

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,20 +16,6 @@ Node.js 20.x が必要です(CIがビルド対象とするバージョン)。
 npm install @openreachtech/hora-ecosystem
 ```
 
-GitHub Packages(`@openreachtech` スコープ)を利用する場合、以下の二項目が必要です。
-
-1. `.npmrc` にレジストリを追記する:
-
-   ```
-   @openreachtech:registry=https://npm.pkg.github.com
-   ```
-
-2. `npm login` で認証する:
-
-   ```sh
-   npm login --registry https://npm.pkg.github.com
-   ```
-
 ES モジュール(`"type": "module"`)です。ESM の `import` 構文でインポートしてください。
 
 ## 使い方

--- a/lib/docs/furo-nuxt/README.md
+++ b/lib/docs/furo-nuxt/README.md
@@ -13,17 +13,7 @@ Node.js is required. If you haven't installed it yet, please do so first.
 | Node.js | ^20.19.2 |
 | npm | ^10.9.0 |
 
-## (2) Setting up `.npmrc`
-
-Create a `.npmrc` file in your project's root directory and add the necessary configuration.
-
-Add the following line to your `.npmrc` file:
-
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
-## (3) Install Command
+## (2) Install Command
 
 You can install `furo` with the following command:
 

--- a/lib/docs/furo-vue/README.md
+++ b/lib/docs/furo-vue/README.md
@@ -10,21 +10,6 @@ Requires Node.js `^20.19.2` and npm `^10.9.0` (the versions the CI builds agains
 npm install @openreachtech/furo-vue
 ```
 
-When using GitHub Packages (the `@openreachtech` scope), the following two items are
-required:
-
-1. Add the registry to your project's `.npmrc`:
-
-   ```
-   @openreachtech:registry=https://npm.pkg.github.com
-   ```
-
-2. Authenticate with `npm login`:
-
-   ```sh
-   npm login --registry https://npm.pkg.github.com
-   ```
-
 ## Getting Started
 
 This guide takes a brand-new project (one that has never used `furo-vue`) from

--- a/lib/docs/furo/README.md
+++ b/lib/docs/furo/README.md
@@ -15,17 +15,7 @@ Node.js is required. If you haven't installed it yet, please do so first.
 | Node.js | ^20.19.2 |
 | npm | ^10.9.0 |
 
-## (2) Setting up `.npmrc`
-
-Create a `.npmrc` file in your project's root directory and add the necessary configuration.
-
-Add the following line to your `.npmrc` file:
-
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
-## (3) Install Command
+## (2) Install Command
 
 You can install `furo` with the following command:
 

--- a/lib/docs/jest-constructor-spy/README.md
+++ b/lib/docs/jest-constructor-spy/README.md
@@ -16,14 +16,6 @@
   npm install --save-dev jest
   ```
 
-* Create a `.npmrc` file in the root directory of your project and add any necessary configurations. This might be required for installing certain npm packages.
-
-* Please add the following line to your `.npmrc` file.
-
-  ```
-  @openreachtech:registry=https://npm.pkg.github.com
-  ```
-
 * You can install `ConstructorSpy` with Jest version 29.5.0 or greater by the following command:
 
   ```

--- a/lib/docs/mentsu-bound-ctor-registry/README.md
+++ b/lib/docs/mentsu-bound-ctor-registry/README.md
@@ -43,21 +43,6 @@ instead of deriving a new one.
 
 Requires Node.js 20.x (the version the CI builds against).
 
-This package is published to GitHub Packages under the `@openreachtech` scope. Before
-installing, the following two steps are required:
-
-1. Add the registry to your project's `.npmrc`:
-
-   ```
-   @openreachtech:registry=https://npm.pkg.github.com
-   ```
-
-2. Authenticate with `npm login`:
-
-   ```sh
-   npm login --registry https://npm.pkg.github.com
-   ```
-
 Then install:
 
 ```sh

--- a/lib/docs/mentsu-gene-chain-splicer/README.md
+++ b/lib/docs/mentsu-gene-chain-splicer/README.md
@@ -9,14 +9,6 @@ A JavaScript utility for dynamically extending object instances by splicing meth
 - Node.js >= 20.0.0
 - npm >= 10.0.0
 
-## Setting up `.npmrc`
-
-This package is published to GitHub Packages. Create a `.npmrc` file in your project root:
-
-```plaintext
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
 ## Install
 
 ```bash

--- a/lib/docs/mentsu-mixin-builder/README.md
+++ b/lib/docs/mentsu-mixin-builder/README.md
@@ -20,21 +20,6 @@ Requires Node.js 20.x (the version the CI builds against).
 npm install @openreachtech/mentsu-mixin-builder
 ```
 
-When using GitHub Packages (the `@openreachtech` scope), the following two items are
-required:
-
-1. Add the registry to your project's `.npmrc`:
-
-   ```
-   @openreachtech:registry=https://npm.pkg.github.com
-   ```
-
-2. Authenticate with `npm login`:
-
-   ```sh
-   npm login --registry https://npm.pkg.github.com
-   ```
-
 It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
 
 ## Usage

--- a/lib/docs/mentsu-random-text-generator/README.md
+++ b/lib/docs/mentsu-random-text-generator/README.md
@@ -10,21 +10,6 @@ Requires Node.js 20.x (the version the CI builds against).
 npm install @openreachtech/mentsu-random-text-generator
 ```
 
-When using GitHub Packages (the `@openreachtech` scope), the following two items are
-required:
-
-1. Add the registry to your project's `.npmrc`:
-
-   ```
-   @openreachtech:registry=https://npm.pkg.github.com
-   ```
-
-2. Authenticate with `npm login`:
-
-   ```sh
-   npm login --registry https://npm.pkg.github.com
-   ```
-
 It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
 
 ## Usage

--- a/lib/docs/mentsu-rootpath/README.md
+++ b/lib/docs/mentsu-rootpath/README.md
@@ -13,16 +13,6 @@ Node.js is required. If you haven't installed it yet, please install it first.
 | Node.js | ^20.14.0 |
 | npm | ^10.9.2 |
 
-## Setting up `.npmrc`
-
-Create a `.npmrc` file in your project's root directory and add the necessary settings.
-
-Add the following line to your `.npmrc` file:
-
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
 ## Command
 
 You can install `mentsu-rootpath` with the following command:

--- a/lib/docs/mentsu-search-condition/README.md
+++ b/lib/docs/mentsu-search-condition/README.md
@@ -15,13 +15,6 @@ tree into SQL / Elasticsearch is the consuming backend's job.
 
 ## Install
 
-GitHub Packages, with a token that has `read:packages`:
-
-```ini
-# .npmrc
-@openreachtech:registry = https://npm.pkg.github.com
-```
-
 ```sh
 npm install @openreachtech/mentsu-search-condition
 ```

--- a/lib/docs/renchan-env/README.md
+++ b/lib/docs/renchan-env/README.md
@@ -15,14 +15,6 @@
   | Node.js | ^20.19.2 |
   | npm | ^10.5.2 |
 
-* Create a `.npmrc` file in the root directory of your project and add any necessary configurations. This might be required for installing certain npm packages.
-
-* Please add the following line to your `.npmrc` file.
-
-  ```
-  @openreachtech:registry=https://npm.pkg.github.com
-  ```
-
 * You can install `renchan-env` with the following command:
 
   ```

--- a/lib/docs/renchan/README.md
+++ b/lib/docs/renchan/README.md
@@ -13,16 +13,6 @@ Node.js is required. If you haven't installed it yet, please do so first.
 | Node.js | ^20.19.2 |
 | npm | ^10.9.0 |
 
-## Setting up `.npmrc`
-
-Create a `.npmrc` file in your project's root directory and add the necessary configuration.
-
-Add the following line to your `.npmrc` file:
-
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
 ## Command
 
 You can install `renchan` with the following command:


### PR DESCRIPTION
# Why

* Close #58

# How

* Twelve documents under `lib/docs/` still told a reader to add `@openreachtech:registry=https://npm.pkg.github.com` to `.npmrc`, and four of them to run `npm login` against it. Every `@openreachtech` package is on npmjs now: the registry line is unnecessary, and following it points npm at a registry where the newer versions were never published
* **These documents ship inside this package** — `files:` carries `lib/` — so a consumer of the catalog reads them, not just a visitor to this repository
* `README.ja.md` carried the same step while `README.md` no longer did. The pair is back in agreement
* The step was written in five shapes (a section, a numbered section, two bullets, a numbered paragraph with `npm login`, and an `ini` fence under `## Install`). Each was removed as a whole unit, and the numbered section renumbered its own siblings only — `## (3) Install Command` became `## (2)`, while the numbering under `# Features` was left alone
