### PR TITLE
🧵 Exclude the `@openreachtech` scope from the release-age quarantine

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 min-release-age = 7
+min-release-age-exclude = @openreachtech/*


### PR DESCRIPTION
# Why

* Close #63

# How

* `.npmrc` here quarantines every newly published version for 7 days, our own scope included. That stops this repository from taking a package the moment it is released: `npm install --package-lock-only` fails with `ETARGET ... with a date before <cutoff>`, so the lock cannot even be written
* It blocks real work right now — the seven `mentsu-*` / `renchan-env` releases of today, and `furo-nuxt@1.12.0` from the 25th, none of which can be pinned here until their week is up
* `hora-boilerplate` already carries `min-release-age-exclude = @openreachtech/*` for exactly this reason. The quarantine is a supply-chain guard against a stranger publishing under a name we depend on; a package this organization publishes is not that risk
