### PR TITLE
📄 Collect the documents again

### DIFF
--- a/lib/docs/furo-nuxt/README.md
+++ b/lib/docs/furo-nuxt/README.md
@@ -1,59 +1,64 @@
-# Overview
+# @openreachtech/furo-nuxt
 
-`furo-nuxt` is a library that supports Nuxt development.
+`furo-nuxt` is a library that brings [furo](https://github.com/openreachtech/furo) into Nuxt applications.
 
-# Installation
+日本語版は [README.ja.md](./README.ja.md) を参照してください。
 
-## (1) `Node.js` and `npm`
+## Concept
 
-Node.js is required. If you haven't installed it yet, please do so first.
+`furo` itself is written in pure JavaScript, so every `furo` feature already works inside a Nuxt application as-is.
 
-| Tool | Version |
-| :-- | :-- |
-| Node.js | ^20.19.2 |
-| npm | ^10.9.0 |
+`furo-nuxt` adds the Nuxt- and Vue-specific layer on top of it:
 
-## (2) Setting up `.npmrc`
+- Composables that bind `furo` clients (GraphQL, RESTful API, subscriptions) to Vue refs.
+- A context class family that keeps component logic out of `<template>` and `setup()`.
+- Ready-made components (dialog, layouts, pagination, tab) and their base stylesheets. Deprecated since 1.12.0, removed in 2.0.0.
+- Tools for loading environment values and sharing them across the Nuxt app.
 
-Create a `.npmrc` file in your project's root directory and add the necessary configuration.
+## Installation
 
-Add the following line to your `.npmrc` file:
+Requires Node.js 20.x (the version the CI builds against).
 
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
-## (3) Install Command
-
-You can install `furo` with the following command:
-
-```
+```sh
 npm install @openreachtech/furo-nuxt
 ```
 
-# Features
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
 
-## (1) Features of `furo`
+## Features
 
-Basically, you can use `furo` features in your Nuxt applications.
+### (1) GraphQL Client
 
-Since `furo` is written in pure JavaScript, all `furo` features work with Nuxt.
+[Usage of GraphQL client](https://github.com/openreachtech/furo-nuxt/blob/main/docs/en/features/graphql-client.md)
 
-## (2) GraphQL Client
+### (2) Form Element Clerk
 
-[Usage of GraphQL client](graphql-client.doc.md)
+[Usage of form element clerk](https://github.com/openreachtech/furo-nuxt/blob/main/docs/en/features/form-clerk.md)
 
-## (3) Form Element Clerk
+### (3) RESTful API Client
 
-[Usage of Form element clerk](form-clerk.doc.md)
+[Usage of RESTful API client](https://github.com/openreachtech/furo-nuxt/blob/main/docs/en/features/restful-api-client.md)
 
-# License
+### (4) Component Context
 
-This project is released under the MIT License.
+[Usage of component context](https://github.com/openreachtech/furo-nuxt/blob/main/docs/en/features/component-context.md)
 
-See [LICENSE](./LICENSE) for details.
+### (5) Components (deprecated since 1.12.0, removed in 2.0.0)
 
-# Contributing
+[Usage of components](https://github.com/openreachtech/furo-nuxt/blob/main/docs/en/features/components.md)
+
+The components, their context classes, `0200.base.css` and `0300.gimmick.css` all leave the package at the next major
+version. Copy what you use into your own app first; the doc above carries the migration steps.
+
+### (6) Application Setup
+
+[Usage of application setup](https://github.com/openreachtech/furo-nuxt/blob/main/docs/en/features/app-setup.md)
+
+## API
+
+[API references](https://github.com/openreachtech/furo-nuxt/blob/main/docs/en/api/index.md)
+
+## Contribution
 
 Bug reports, feature requests, and code contributions are welcome.
 
@@ -67,10 +72,16 @@ npm run lint
 npm test
 ```
 
-# Developers
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
 
 [Open Reach Tech Inc.](https://openreach.tech)
 
-# Copyright
+## Copyright
 
 © 2025 Open Reach Tech Inc.

--- a/lib/docs/furo-vue/README.md
+++ b/lib/docs/furo-vue/README.md
@@ -10,21 +10,6 @@ Requires Node.js `^20.19.2` and npm `^10.9.0` (the versions the CI builds agains
 npm install @openreachtech/furo-vue
 ```
 
-When using GitHub Packages (the `@openreachtech` scope), the following two items are
-required:
-
-1. Add the registry to your project's `.npmrc`:
-
-   ```
-   @openreachtech:registry=https://npm.pkg.github.com
-   ```
-
-2. Authenticate with `npm login`:
-
-   ```sh
-   npm login --registry https://npm.pkg.github.com
-   ```
-
 ## Getting Started
 
 This guide takes a brand-new project (one that has never used `furo-vue`) from
@@ -171,12 +156,54 @@ Mount `<FuroToaster />` once near your app root, then call the imperative
 ```js
 import {
   toast,
-} from '@openreachtech/furo-vue/toast'
+} from '@openreachtech/furo-vue'
 
 toast.show({ title: 'Saved', type: 'success' })
 ```
 
-### (7) Discover every component
+### (7) Icons the library does not ship
+
+Icons resolve offline, so `FuroIcon` draws only the data it holds: the 49 icons
+the library ships, plus whatever your application registers. Register yours once
+at start-up, before the first render:
+
+```js
+import {
+  furoIconRegistry,
+} from '@openreachtech/furo-vue/icons'
+
+furoIconRegistry.registerIconSet({
+  iconSet: applicationIconSet,
+})
+```
+
+A name nothing resolves throws outside a production build, naming the icon, so a
+missing icon never hides as an empty box. A production build draws the warning
+glyph instead.
+
+To reach every name rather than registering them one by one, install your own
+renderer. The registry still answers first, so the library's own icons keep
+drawing offline whatever you install:
+
+```js
+furoIconRegistry.useIconRenderer({
+  component: applicationIconComponent,
+})
+```
+
+A Nuxt application gets this from the module instead:
+
+```js
+// nuxt.config.js
+modules: ['@nuxt/icon', '@openreachtech/furo-vue/nuxt']
+```
+
+A plain Vue application gets it from `createIconifyRenderer()`, exported at
+`@openreachtech/furo-vue/icon-renderers`. Full API, including single-icon
+registration and a lazy resolver:
+[docs/furo-icon.md](https://github.com/openreachtech/furo-vue/blob/main/docs/furo-icon.md).
+
+### (8) Discover every component
 
 - Human catalog (grouped by layer, with use cases): [docs/COMPONENTS.md](https://github.com/openreachtech/furo-vue/blob/main/docs/COMPONENTS.md)
 - Machine-readable manifest (for AI agents and tooling): `public/furo-vue/components.json`
@@ -188,12 +215,12 @@ Maintainers regenerate these from the doc registry with:
 npm run docs:manifest
 ```
 
-### (8) GraphQL, fetchers, and page templates (out of scope here)
+### (9) GraphQL, fetchers, and page templates (out of scope here)
 
 `furo-vue` ships presentational atoms, molecules, and organisms only. GraphQL
 launchers, fetcher/submitter adapters, and page-level templates (ListView,
 DetailView, …) live in the consumer app. See
-[docs/product/overview.md](https://github.com/openreachtech/furo-vue/blob/main/docs/product/overview.md)
+[docs/furo-vue/README.md](https://github.com/openreachtech/furo-vue/blob/main/docs/furo-vue/README.md)
 for the scope boundary and
 [docs/furo-vue/architecture.md](https://github.com/openreachtech/furo-vue/blob/main/docs/furo-vue/architecture.md)
 for layer rules.
@@ -293,7 +320,7 @@ npm test
 
 ## License
 
-This project is released under the MIT License.
+This project is released under the Apache License 2.0.
 
 For more details, please see [in the LICENSE file](./LICENSE).
 

--- a/lib/docs/furo/README.md
+++ b/lib/docs/furo/README.md
@@ -1,59 +1,54 @@
-# Overview
+# furo
 
 `furo` is a library that supports front-end development.
 
 Since it is written in pure JavaScript, it works with any front-end framework or library, such as Vue or React.
 
-# Installation
+## Installation
 
-## (1) `Node.js` and `npm`
+Requires Node.js 20.x or later.
 
-Node.js is required. If you haven't installed it yet, please do so first.
-
-| Tool | Version |
-| :-- | :-- |
-| Node.js | ^20.19.2 |
-| npm | ^10.9.0 |
-
-## (2) Setting up `.npmrc`
-
-Create a `.npmrc` file in your project's root directory and add the necessary configuration.
-
-Add the following line to your `.npmrc` file:
-
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
-## (3) Install Command
-
-You can install `furo` with the following command:
-
-```
+```sh
 npm install @openreachtech/furo
 ```
 
-# Features
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
 
-## (1) GraphQL Client
+## Features
 
-[Usage of GraphQL client](graphql-client.doc.md)
+### (1) GraphQL Client
 
-## (2) Form Element Clerk
+[Usage of GraphQL client](https://github.com/openreachtech/furo-core/blob/main/docs/en/features/graphql-client.md)
 
-[Usage of Form element clerk](form-clerk.doc.md)
+### (2) RESTful API Client
 
-## (3) Storage Clerk
+[Usage of RESTful API client](https://github.com/openreachtech/furo-core/blob/main/docs/en/features/restful-api-client.md)
 
-[Usage of Storage clerk](storage-clerk.doc.md)
+### (3) Form Element Clerk
 
-# License
+[Usage of form element clerk](https://github.com/openreachtech/furo-core/blob/main/docs/en/features/form-element-clerk.md)
 
-This project is released under the MIT License.
+### (4) Storage Clerk
 
-See [LICENSE](./LICENSE) for details.
+[Usage of storage clerk](https://github.com/openreachtech/furo-core/blob/main/docs/en/features/storage-clerk.md)
 
-# Contributing
+### (5) IndexedDB Client
+
+[Usage of IndexedDB client](https://github.com/openreachtech/furo-core/blob/main/docs/en/features/indexed-db-client.md)
+
+### (6) HTTP Client Tools
+
+[Usage of HTTP client tools](https://github.com/openreachtech/furo-core/blob/main/docs/en/features/client-tools.md)
+
+### (7) Dynamic Class Declaration
+
+[Usage of dynamic class declaration](https://github.com/openreachtech/furo-core/blob/main/docs/en/features/dynamic-class-declaration.md)
+
+## API
+
+[API reference](https://github.com/openreachtech/furo-core/blob/main/docs/en/api/index.md)
+
+## Contribution
 
 Bug reports, feature requests, and code contributions are welcome.
 
@@ -67,10 +62,16 @@ npm run lint
 npm test
 ```
 
-# Developers
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
 
 [Open Reach Tech Inc.](https://openreach.tech)
 
-# Copyright
+## Copyright
 
 © 2025 Open Reach Tech Inc.

--- a/lib/docs/mentsu-bound-ctor-registry/README.md
+++ b/lib/docs/mentsu-bound-ctor-registry/README.md
@@ -43,22 +43,7 @@ instead of deriving a new one.
 
 Requires Node.js 20.x (the version the CI builds against).
 
-This package is published to GitHub Packages under the `@openreachtech` scope. Before
-installing, the following two steps are required:
-
-1. Add the registry to your project's `.npmrc`:
-
-   ```
-   @openreachtech:registry=https://npm.pkg.github.com
-   ```
-
-2. Authenticate with `npm login`:
-
-   ```sh
-   npm login --registry https://npm.pkg.github.com
-   ```
-
-Then install:
+Install it with npm:
 
 ```sh
 npm install @openreachtech/mentsu-bound-ctor-registry
@@ -144,7 +129,7 @@ npm test
 
 ## License
 
-This project is released under the MIT License.
+This project is released under the Apache License 2.0.
 
 For more details, please see [in the LICENSE file](./LICENSE).
 

--- a/lib/docs/mentsu-deep-loader/README.md
+++ b/lib/docs/mentsu-deep-loader/README.md
@@ -1,0 +1,134 @@
+# @openreachtech/mentsu-deep-loader
+
+Deep class loader modules — recursively import modules under a directory and collect their exports, with optional filtering by constructor.
+
+## Concept
+
+`mentsu-deep-loader` walks a directory tree (a "pool") recursively, dynamically
+`import()`s every JavaScript file it finds, and collects the values you care
+about. It is useful for auto-registering models, resolvers, config objects, or
+any set of modules that live under a directory without listing them one by one.
+
+- `DeepLoader` — the base loader. Collects the `default` export of every module
+  under a pool path. Its behavior is customizable through override hooks.
+- `DeepCtorsLoader` — a loader specialized for constructors. It keeps only the
+  loaded values that are (or extend) one of the acceptable constructors you
+  bind to it.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/mentsu-deep-loader
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+### Load default exports from a directory
+
+```js
+import { DeepLoader } from '@openreachtech/mentsu-deep-loader'
+
+const alphaLoader = DeepLoader.create({
+  poolPath: 'app/models',
+})
+
+const loadedModules = await alphaLoader.deepLoad()
+// => the default export of every module found recursively under app/models
+```
+
+### Load only constructors of a given base class
+
+Bind acceptable constructors with `.of()`, then load. Only values that are one
+of the acceptable constructors — or a subclass of them — are kept.
+
+```js
+import { DeepCtorsLoader } from '@openreachtech/mentsu-deep-loader'
+
+import BaseModel from './app/models/BaseModel.js'
+
+const ModelLoader = DeepCtorsLoader.of(BaseModel)
+
+const betaLoader = ModelLoader.create({
+  poolPath: 'app/models',
+})
+
+const loadedCtors = await betaLoader.deepLoad()
+// => only constructors that are BaseModel or extend it
+```
+
+You can also pass the acceptable constructors directly to `.create()`:
+
+```js
+const gammaLoader = DeepCtorsLoader.create({
+  poolPath: 'app/models',
+  acceptableCtors: [
+    BaseModel,
+  ],
+})
+```
+
+### Customize loading behavior
+
+Subclass `DeepLoader` and override the hooks to change which files are imported,
+which value is collected per module, and which values are kept.
+
+```js
+import { DeepLoader } from '@openreachtech/mentsu-deep-loader'
+
+class JsonModuleLoader extends DeepLoader {
+  /** @override */
+  defineFileNameFilter () {
+    return ({ filename }) =>
+      filename.endsWith('.config.js')
+  }
+}
+```
+
+## API
+
+Class members are written with the following notation.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+See the [API reference](https://github.com/openreachtech/mentsu-deep-loader/blob/main/docs/en/api/index.md) for each class.
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/mentsu-deep-loader.git
+cd mentsu-deep-loader
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/mentsu-deep-value-converter/README.md
+++ b/lib/docs/mentsu-deep-value-converter/README.md
@@ -1,0 +1,121 @@
+# @openreachtech/mentsu-deep-value-converter
+
+Recursively converts values in a nested object using declarative ValueConverter mappings.
+
+## Overview
+
+`mentsu-deep-value-converter` lets you declare, once, how each leaf value inside a
+nested object should be converted, and then apply that declaration to any object with
+the same shape.
+
+You describe the conversion as a **converter hash**: a plain object that mirrors the
+shape of your data, whose leaves are configured `ValueConverter` classes. A
+`DeepValueConverter` walks the input object along that shape and converts every matching
+leaf. Leaves that cannot be converted become `null`, and unmapped leaves are left
+untouched.
+
+The package ships with ready-to-use converters (BigNumber, date-only string, and `Date`
+conversions) and exposes an abstract base class so you can write your own.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/mentsu-deep-value-converter
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+Build a converter hash whose leaves are configured converters (each built-in converter
+is configured with `.by()`), create a `DeepValueConverter`, then call `deepConvert()`:
+
+```js
+import {
+  DeepValueConverter,
+  DateToDateonlyValueConverter,
+  DateonlyToDateValueConverter,
+} from '@openreachtech/mentsu-deep-value-converter'
+
+const alphaConverter = DeepValueConverter.create({
+  converterHash: {
+    user: {
+      pointsOn: DateToDateonlyValueConverter.by({
+        timezone: 'Asia/Tokyo',
+      }),
+      profile: {
+        savedOn: DateonlyToDateValueConverter.by({
+          timezone: 'UTC',
+        }),
+      },
+    },
+  },
+})
+
+const alphaConvertedValue = alphaConverter.deepConvert({
+  value: {
+    user: {
+      pointsOn: new Date('2026-03-01T00:00:00.000Z'),
+      profile: {
+        savedOn: '2026-03-20',
+      },
+    },
+  },
+})
+
+// alphaConvertedValue:
+// {
+//   user: {
+//     pointsOn: '2026-03-01',                          // Date -> 'yyyy-mm-dd'
+//     profile: {
+//       savedOn: new Date('2026-03-20T00:00:00.000Z'), // 'yyyy-mm-dd' -> Date
+//     },
+//   },
+// }
+```
+
+A leaf whose value cannot be converted (wrong type, invalid format, etc.) becomes
+`null`. Passing a nullish `value` returns `null`.
+
+### Built-in converters
+
+- `BigNumberToFixedValueConverter` — `BigNumber` to a fixed-point string.
+- `DateonlyToDateValueConverter` — a `yyyy-mm-dd` string to a `Date`.
+- `DateToDateonlyValueConverter` — a `Date` to a `yyyy-mm-dd` string.
+
+You can also write your own converter by extending `BaseValueConverter`. See the API
+reference for details.
+
+## API
+
+See the [API reference](https://github.com/openreachtech/mentsu-deep-value-converter/blob/main/docs/en/api/index.md).
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/mentsu-deep-value-converter.git
+cd mentsu-deep-value-converter
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/mentsu-field-path-value-extractor/README.md
+++ b/lib/docs/mentsu-field-path-value-extractor/README.md
@@ -195,7 +195,7 @@ npm test
 
 ## License
 
-This project is released under the MIT License.
+This project is released under the Apache License 2.0.
 
 For more details, please see [in the LICENSE file](./LICENSE).
 

--- a/lib/docs/mentsu-gene-chain-splicer/README.md
+++ b/lib/docs/mentsu-gene-chain-splicer/README.md
@@ -9,14 +9,6 @@ A JavaScript utility for dynamically extending object instances by splicing meth
 - Node.js >= 20.0.0
 - npm >= 10.0.0
 
-## Setting up `.npmrc`
-
-This package is published to GitHub Packages. Create a `.npmrc` file in your project root:
-
-```plaintext
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
 ## Install
 
 ```bash
@@ -195,7 +187,7 @@ npm test
 
 # License
 
-This project is released under the MIT License.
+This project is released under the Apache License 2.0.
 
 For more details, please see [in the LICENSE file](./LICENSE).
 

--- a/lib/docs/mentsu-logger/README.md
+++ b/lib/docs/mentsu-logger/README.md
@@ -158,7 +158,7 @@ npm test
 
 ## License
 
-This project is released under the MIT License.
+This project is released under the Apache License 2.0.
 
 For more details, please see [in the LICENSE file](./LICENSE).
 

--- a/lib/docs/mentsu-path-group-schema/README.md
+++ b/lib/docs/mentsu-path-group-schema/README.md
@@ -133,7 +133,9 @@ npm test
 
 ## License
 
-UNLICENSED
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
 
 ## Developer
 

--- a/lib/docs/mentsu-process-clerk/README.md
+++ b/lib/docs/mentsu-process-clerk/README.md
@@ -1,0 +1,183 @@
+# @openreachtech/mentsu-process-clerk
+
+A small clerk class that manages Node.js process event listeners (sinks) and provides convenient process-exit helpers.
+
+## Overview
+
+`ProcessClerk` wraps a Node.js `process` object and offers two things:
+
+- Attaching and detaching a **sink** — a plain object that maps process event names (e.g. `SIGINT`, `SIGTERM`) to their listener functions — in one call.
+- Exiting the process with well-known exit codes through readable helper methods.
+
+By taking the `process` object as a constructor parameter, the clerk stays easy to test: a mock process can be injected instead of the real one.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/mentsu-process-clerk
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+Create a clerk, attach a sink of process event listeners, and exit gracefully when a
+signal arrives.
+
+```js
+import { ProcessClerk } from '@openreachtech/mentsu-process-clerk'
+
+const alphaClerk = ProcessClerk.create()
+
+const alphaSink = {
+  SIGINT: () => {
+    console.log('Received SIGINT, shutting down...')
+
+    alphaClerk.exitBySigint()
+  },
+}
+
+// Attach the listeners to the process.
+alphaClerk.attachSink({
+  sink: alphaSink,
+})
+
+// Later, detach them when they are no longer needed.
+alphaClerk.detachSink({
+  sink: alphaSink,
+})
+```
+
+## API
+
+Class members are written with the following notation.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+### `ProcessClerk`
+
+Clerk to manage process event sinks.
+
+#### `.create()`
+
+Factory method. Creates a new instance.
+
+```
+.create({ rawProcess? }?) => ProcessClerk
+```
+
+| parameter | type | description |
+| :-- | :-- | :-- |
+| `rawProcess` | `NodeJS.Process` | The process object to manage. Optional. Defaults to the global `process`. |
+
+#### `#attachSink()`
+
+Attaches a sink to the process. Each entry of the sink is registered with `process.on(eventName, listener)`.
+
+```
+#attachSink({ sink? }) => NodeJS.Process | null
+```
+
+| parameter | type | description |
+| :-- | :-- | :-- |
+| `sink` | `Record<string, (...args: Array<*>) => void> \| null` | Map of event names to listener functions. Optional. Defaults to `null`. |
+
+Returns the process with the listeners attached, or `null` when the sink is invalid
+(not an object, or containing a value that is not a function).
+
+#### `#detachSink()`
+
+Detaches a sink from the process. Each entry of the sink is removed with `process.off(eventName, listener)`.
+
+```
+#detachSink({ sink? }) => NodeJS.Process | null
+```
+
+| parameter | type | description |
+| :-- | :-- | :-- |
+| `sink` | `Record<string, (...args: Array<*>) => void> \| null` | Map of event names to listener functions. Optional. Defaults to `null`. |
+
+Returns the process with the listeners detached, or `null` when the sink is invalid.
+
+#### `#exitAsSuccess()`
+
+Exits the process as success (exit code `0`).
+
+```
+#exitAsSuccess() => void
+```
+
+#### `#exitAsFailure()`
+
+Exits the process as failure (exit code `1`).
+
+```
+#exitAsFailure() => void
+```
+
+#### `#exitAsMisuse()`
+
+Exits the process as misuse (exit code `2`).
+
+```
+#exitAsMisuse() => void
+```
+
+#### `#exitBySigint()`
+
+Exits the process by SIGINT (exit code `130`).
+
+```
+#exitBySigint() => void
+```
+
+#### `#exit()`
+
+Exits the process with the given exit code.
+
+```
+#exit({ exitCode? }?) => void
+```
+
+| parameter | type | description |
+| :-- | :-- | :-- |
+| `exitCode` | `number` | The exit code passed to `process.exit()`. Optional. Defaults to `0`. |
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/mentsu-process-clerk.git
+cd mentsu-process-clerk
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/mentsu-random-text-generator/README.md
+++ b/lib/docs/mentsu-random-text-generator/README.md
@@ -10,21 +10,6 @@ Requires Node.js 20.x (the version the CI builds against).
 npm install @openreachtech/mentsu-random-text-generator
 ```
 
-When using GitHub Packages (the `@openreachtech` scope), the following two items are
-required:
-
-1. Add the registry to your project's `.npmrc`:
-
-   ```
-   @openreachtech:registry=https://npm.pkg.github.com
-   ```
-
-2. Authenticate with `npm login`:
-
-   ```sh
-   npm login --registry https://npm.pkg.github.com
-   ```
-
 It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
 
 ## Usage
@@ -127,7 +112,7 @@ npm test
 
 ## License
 
-This project is released under the MIT License.
+This project is released under the Apache License 2.0.
 
 For more details, please see [in the LICENSE file](./LICENSE).
 

--- a/lib/docs/mentsu-rocket-client/README.md
+++ b/lib/docs/mentsu-rocket-client/README.md
@@ -1,0 +1,245 @@
+# @openreachtech/mentsu-rocket-client
+
+A small, class-based REST client framework for building type-safe HTTP API clients.
+
+Each API endpoint is modeled as three cooperating classes — a **Payload** (what to send),
+a **Launcher** (how to send it), and a **Capsule** (what came back) — so that request
+building, transport, and response handling stay separated and easy to extend.
+
+## Table of contents
+
+- [Concept](#concept)
+- [Installation](#installation)
+- [Usage](#usage)
+- [API](#api)
+- [Contribution](#contribution)
+- [License](#license)
+- [Developer](#developer)
+- [Copyright](#copyright)
+
+## Concept
+
+An API call is described by three classes you extend:
+
+| Class | Responsibility |
+| :-- | :-- |
+| `BasePayload` | Describes one endpoint: HTTP method, pathname (with path parameters), query, body, `Content-Type`, and authorization. Builds the `fetch` `Request`. |
+| `BaseLauncher` | Holds the client configuration (base URL), wires a `Payload` to a `Capsule`, and runs the request through `fetch` with optional lifecycle hooks. |
+| `BaseCapsule` | Wraps the raw `Response`: exposes the parsed body and status code, and answers whether the call succeeded or which error occurred. |
+
+Optionally, a `BaseEntity` can be bound to the triad with `.via(EntityCtor)` so that
+responses are materialized into your own domain objects.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+This package is published to GitHub Packages under the `@openreachtech` scope. Before
+installing, the following two steps are required:
+
+1. Add the registry to your project's `.npmrc`:
+
+   ```
+   @openreachtech:registry=https://npm.pkg.github.com
+   ```
+
+2. Authenticate with `npm login`:
+
+   ```sh
+   npm login --registry https://npm.pkg.github.com
+   ```
+
+Then install:
+
+```sh
+npm install @openreachtech/mentsu-rocket-client
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+### 1. Define an endpoint
+
+Extend `BasePayload`, `BaseCapsule`, and `BaseLauncher` to describe one endpoint.
+
+```js
+import {
+  BaseLauncher,
+  BasePayload,
+  BaseCapsule,
+  REST_METHOD,
+} from '@openreachtech/mentsu-rocket-client'
+
+class GetCustomerPayload extends BasePayload {
+  /** @override */
+  static get method () {
+    return REST_METHOD.GET
+  }
+
+  /** @override */
+  static get pathname () {
+    return '/customers/[customerId]' // [customerId] is filled from pathParameterHash
+  }
+
+  /** @override */
+  static get contentType () {
+    return 'application/json'
+  }
+}
+
+class GetCustomerCapsule extends BaseCapsule {}
+
+class GetCustomerLauncher extends BaseLauncher {
+  /** @override */
+  static get clientConfig () {
+    return {
+      BASE_URL: 'https://api.example.com',
+    }
+  }
+
+  /** @override */
+  static get Payload () {
+    return GetCustomerPayload
+  }
+
+  /** @override */
+  static get Capsule () {
+    return GetCustomerCapsule
+  }
+}
+```
+
+### 2. Launch a request
+
+```js
+const launcher = GetCustomerLauncher.create()
+
+const payload = GetCustomerLauncher.createPayload({
+  pathParameterHash: {
+    customerId: 10001,
+  },
+  query: {
+    includesDeleted: false,
+  },
+})
+
+const capsule = await launcher.launchRequest({
+  payload,
+})
+
+if (capsule.hasError()) {
+  console.error(capsule.getErrorMessage()) // error code string
+} else {
+  console.log(capsule.statusCode) // e.g. 200
+  console.log(capsule.body) // parsed response body
+}
+```
+
+### 3. Lifecycle hooks
+
+`beforeRequest` can abort the request (return `true`); `afterRequest` observes the
+resolved capsule.
+
+```js
+const capsule = await launcher.launchRequest({
+  payload,
+  hooks: {
+    async beforeRequest (payload) {
+      return false // return true to abort the request
+    },
+    async afterRequest (capsule) {
+      // inspect the resolved capsule
+    },
+  },
+})
+```
+
+### 4. Authorization
+
+Set an authorization builder and the API key on the payload. `BearerAuthorizationBuilder`
+and `BasicAuthorizationBuilder` are provided.
+
+```js
+import {
+  BasePayload,
+  BearerAuthorizationBuilder,
+  REST_METHOD,
+} from '@openreachtech/mentsu-rocket-client'
+
+class CreateOrderPayload extends BasePayload {
+  /** @override */
+  static get method () {
+    return REST_METHOD.POST
+  }
+
+  /** @override */
+  static get pathname () {
+    return '/orders'
+  }
+
+  /** @override */
+  static get contentType () {
+    return 'application/json'
+  }
+
+  /** @override */
+  static get AuthorizationBuilderCtor () {
+    return BearerAuthorizationBuilder
+  }
+
+  /** @override */
+  static get authorizationApiKey () {
+    return process.env.API_TOKEN // credential source
+  }
+}
+```
+
+### Notes
+
+- **Validation**: assign a schema to the static `querySchema` / `bodySchema` fields of a
+  `Payload`, or to `bodySchema` of a `Capsule`, to validate inputs and normalize the
+  response body. A payload with an invalid query, body, or path parameter resolves to a
+  capsule whose `hasError()` is `true`.
+- **Key casing**: use `SnakeCasedKeyRequestQuery` / `SnakeCasedKeyRequestBody` to send
+  `snake_case` keys over the wire, and `CamelCasedKeyResponseBody` to receive
+  `camelCase` keys in JavaScript.
+- **Body format**: the default request body is JSON. Set `BodyStringifierCtor` to
+  `NdjsonRequestBodyStringifier` for NDJSON.
+- **Response parsing**: override `ResponseBodyParser` on the launcher to change how the
+  response body is parsed (`JsonResponseBodyParser` by default, `BlobResponseBodyParser`
+  for binary responses).
+
+## API
+
+Detailed API references for the base classes are split by class:
+
+[API references](https://github.com/openreachtech/mentsu-rocket-client/blob/main/docs/en/api/index.md)
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/mentsu-rocket-client.git
+cd mentsu-rocket-client
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/mentsu-rootpath/README.md
+++ b/lib/docs/mentsu-rootpath/README.md
@@ -13,16 +13,6 @@ Node.js is required. If you haven't installed it yet, please install it first.
 | Node.js | ^20.14.0 |
 | npm | ^10.9.2 |
 
-## Setting up `.npmrc`
-
-Create a `.npmrc` file in your project's root directory and add the necessary settings.
-
-Add the following line to your `.npmrc` file:
-
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
 ## Command
 
 You can install `mentsu-rootpath` with the following command:
@@ -55,7 +45,7 @@ console.log(
 
 # License
 
-This project is released under the MIT License.
+This project is released under the Apache License 2.0.
 
 For more details, please see [in the LICENSE file](./LICENSE).
 

--- a/lib/docs/mentsu-schema/README.md
+++ b/lib/docs/mentsu-schema/README.md
@@ -1,0 +1,154 @@
+# @openreachtech/mentsu-schema
+
+Schema modules for Mentsu — convert values between their in-application form and their serializable form, and validate them against a declared schema.
+
+## Concept
+
+A value in Mentsu is handled in two representations:
+
+- **Normalized value** — the rich, in-application form. For example a `Date`, a `BigNumber`, a `bigint`, or a constraint document instance.
+- **Denormalized value** — the plain, serializable form used at boundaries such as JSON payloads. For example an ISO datetime string, or a decimal string.
+
+A **schema** is declared from scalar constructors and plain JavaScript structures (objects and arrays). `SchemaReifier` walks the schema to:
+
+- **normalize** a denormalized value (inflate it into the in-application form),
+- **denormalize** a normalized value (serialize it back to the plain form),
+- **validate** whether a value fulfills the schema.
+
+Each leaf of the schema is a **scalar** (see the [scalar catalog](https://github.com/openreachtech/mentsu-schema/blob/main/docs/en/api/index.md)). Scalars can be nested through `CompositeScalar` (objects and tuples/arrays), `RecordScalar` (uniform-valued maps), and `UnionScalar` (alternatives), so a schema can describe an arbitrarily deep structure.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+This package is published to GitHub Packages under the `@openreachtech` scope. Before
+installing, the following two steps are required:
+
+1. Add the registry to your project's `.npmrc`:
+
+   ```
+   @openreachtech:registry=https://npm.pkg.github.com
+   ```
+
+2. Authenticate with `npm login`:
+
+   ```sh
+   npm login --registry https://npm.pkg.github.com
+   ```
+
+Then install:
+
+```sh
+npm install @openreachtech/mentsu-schema
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+Declare a schema and reify values with it.
+
+```js
+import {
+  SchemaReifier,
+  IntegerScalar,
+  KeywordScalar,
+  DatetimeScalar,
+} from '@openreachtech/mentsu-schema'
+
+const alphaReifier = SchemaReifier.create({
+  rawSchema: {
+    id: IntegerScalar,
+    label: KeywordScalar,
+    pointsAt: DatetimeScalar,
+  },
+})
+
+// Denormalized (wire) -> normalized (in-application)
+const normalizedValue = alphaReifier.normalizeValue({
+  denormalizedValue: {
+    id: 100001,
+    label: 'alpha',
+    pointsAt: '2025-08-11T11:00:00.001Z',
+  },
+})
+// normalizedValue.pointsAt is now a Date instance.
+
+// Normalized (in-application) -> denormalized (wire)
+const denormalizedValue = alphaReifier.denormalizeValue({
+  normalizedValue,
+})
+// denormalizedValue.pointsAt is back to the ISO string.
+
+// Validation
+const isValid = alphaReifier.isFulfilledDenormalizedValue({
+  denormalizedValue: {
+    id: 100001,
+    label: 'alpha',
+    pointsAt: '2025-08-11T11:00:00.001Z',
+  },
+})
+```
+
+To reuse a schema, derive a schema-bound reifier class with `.as()`; its `.create()` then needs no schema argument.
+
+```js
+const AlphaReifier = SchemaReifier.as({
+  id: IntegerScalar,
+  label: KeywordScalar,
+  pointsAt: DatetimeScalar,
+})
+
+const alphaReifier = AlphaReifier.create()
+```
+
+A field becomes optional (accepts `null`) with the `asNullable` variant of a scalar.
+
+```js
+const betaReifier = SchemaReifier.create({
+  rawSchema: {
+    id: IntegerScalar,
+    label: KeywordScalar.asNullable, // may be null
+  },
+})
+```
+
+## API
+
+See the [API reference](https://github.com/openreachtech/mentsu-schema/blob/main/docs/en/api/index.md) for the full class documentation and the scalar catalog.
+
+The package exports:
+
+- `SchemaReifier` — declares a schema and normalizes / denormalizes / validates values against it.
+- `DeepSchemaInflater` — binds `NodeScalar` families in a schema to their constraint constructors.
+- `BaseScalar` — the base class for all scalars; extend it to define a custom scalar.
+- The concrete scalars: `BigIntScalar`, `BigNumberScalar`, `BooleanScalar`, `CompositeScalar`, `DateonlyScalar`, `DatetimeScalar`, `DoubleScalar`, `IntegerScalar`, `KeywordScalar`, `NodeScalar`, `PatternScalar`, `RecordScalar`, `SentinelScalar`, `TextScalar`, `ToCaseKeywordScalar`, `UnionScalar`.
+- `ScalarHash` — a hash of the concrete scalars keyed by short aliases (`BigNum`, `Bool`, `Composite`, `Dateonly`, `Datetime`, `Double`, `Integer`, `Keyword`, `Long`, `Node`, `Pattern`, `Record`, `Sentinel`, `Text`, `ToCaseKeyword`, `Union`).
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/mentsu-schema.git
+cd mentsu-schema
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/mentsu-search-condition/README.md
+++ b/lib/docs/mentsu-search-condition/README.md
@@ -13,14 +13,9 @@ tree into SQL / Elasticsearch is the consuming backend's job.
 > Read [`docs/en/ai-context.md`](https://github.com/openreachtech/mentsu-search-condition/blob/main/docs/en/ai-context.md)
 > for the full API reference and the backend integration contract.
 
-## Install
+## Installation
 
-GitHub Packages, with a token that has `read:packages`:
-
-```ini
-# .npmrc
-@openreachtech:registry = https://npm.pkg.github.com
-```
+Requires Node.js 20.x (the version the CI builds against).
 
 ```sh
 npm install @openreachtech/mentsu-search-condition
@@ -193,7 +188,9 @@ npm test
 
 ## License
 
-UNLICENSED
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
 
 ## Developer
 

--- a/lib/docs/mentsu-text-case-tools/README.md
+++ b/lib/docs/mentsu-text-case-tools/README.md
@@ -1,0 +1,84 @@
+# @openreachtech/mentsu-text-case-tools
+
+Utilities for converting text case, and for deeply converting the keys of plain objects, between camelCase, PascalCase, and delimiter case (such as `snake_case` or `kebab-case`).
+
+## Table of contents
+
+- [Installation](#installation)
+- [Features](#features)
+- [API](#api)
+- [Contribution](#contribution)
+- [License](#license)
+- [Developer](#developer)
+- [Copyright](#copyright)
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+This package is published to GitHub Packages under the `@openreachtech` scope. Before
+installing, the following two steps are required:
+
+1. Add the registry to your project's `.npmrc`:
+
+   ```
+   @openreachtech:registry=https://npm.pkg.github.com
+   ```
+
+2. Authenticate with `npm login`:
+
+   ```sh
+   npm login --registry https://npm.pkg.github.com
+   ```
+
+Then install:
+
+```sh
+npm install @openreachtech/mentsu-text-case-tools
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Features
+
+### (1) Text case conversion
+
+[Usage of TextCaseConverter](https://github.com/openreachtech/mentsu-text-case-tools/blob/main/docs/en/features/text-case-converter.md)
+
+### (2) Deep object key case conversion
+
+[Usage of DeepKeyCaseConverter](https://github.com/openreachtech/mentsu-text-case-tools/blob/main/docs/en/features/deep-key-case-converter.md)
+
+## API
+
+This package exposes the `TextCaseConverter` and `DeepKeyCaseConverter` classes.
+
+See the [API reference](https://github.com/openreachtech/mentsu-text-case-tools/blob/main/docs/en/api/index.md) for the members of each class.
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/mentsu-text-case-tools.git
+cd mentsu-text-case-tools
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/mentsu-validation-rules/README.md
+++ b/lib/docs/mentsu-validation-rules/README.md
@@ -1,96 +1,134 @@
 # @openreachtech/mentsu-validation-rules
 
-A **DB-independent, pure-logic** validation rule engine extracted from crm-kit (renchan)'s validation foundation.
+A **DB-agnostic, pure-logic** validation rule engine, extracted from the crm-kit
+(renchan) validation core.
 
-It evaluates a condition tree (a recursive composition of `AND` / `OR` plus field operators) and reports "which column, with which operator, was violated / satisfied / unevaluable." Retrieving the actual values (from a DB, an entity, or the clock) is delegated to a `ValueResolver` injected by the host, so the package itself carries no vocabulary for DB, GraphQL, or fieldPath concepts.
+It evaluates a condition tree (`AND` / `OR` recursion plus field operators) and reports
+which column violated, passed, or could not be evaluated — and with which operator.
+Resolving the actual value (from the DB, an entity, or the clock) is delegated to a
+host-injected `ValueResolver`, so the package itself carries no vocabulary of DB, GraphQL,
+or field paths.
 
-> See [`docs/v1.0.0/`](./docs/v1.0.0/) for design details.
-> See [`docs/operators.md`](./docs/operators.md) for the per-operator `operands` / `options` specification.
+## Concept
 
-## Basic Contract
+- **Input / output**: `execute({ rules, record })` → a `ColumnValidationParcel`. The input
+  is an array of "parsed condition tree plus metadata".
+- **No-throw (fail-safe)**: the public entry never throws or rejects. Unknown operators,
+  value-resolution failures, and the like are isolated as *errored* and, by default, are
+  not counted as violations (switch to fail-closed with `treatErrorAsViolation: true`).
+- **Open–Closed**: every class has a `constructor` plus a `static create()`, with behavior
+  on instance methods, so any class can be replaced by `extends`. Operators are added
+  through `create({ customSuites })`, and a duplicate `operatorKey` overrides the built-in
+  (last one wins).
+- **Sync / async**: operators and record validators may be implemented either
+  synchronously or asynchronously (the evaluation path always `await`s).
 
-- **I/O**: `execute({ rules, record })` → `ColumnValidationParcel`. The input is an array of "parsed condition trees plus metadata."
-- **No-Throw (fail-safe)**: the public entry point never throws / rejects. Unknown operators, value-resolution failures, and the like are separated out as "errored" and are not counted as violations by default (switch to fail-closed with `treatErrorAsViolation: true`).
-- **Extensibility (Open-Closed)**: every class has a `constructor` plus a `static create()`, with behavior kept in instance methods. Any class can be swapped out via `extends`. Operators can be injected on top of the built-ins via `create({ customSuites })`, and the same `operatorKey` can be overridden — the last registration wins.
-- **Sync / Async**: operators and record validators can be implemented either synchronously or asynchronously (the evaluation path always `await`s).
+## Installation
 
-## Quick Start
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/mentsu-validation-rules
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+### Quick start
 
 ```javascript
 import {
   ValidationEngine,
 } from '@openreachtech/mentsu-validation-rules'
 
-// 値解決はホストが実装（BaseValueResolver を継承し resolveValueSource を実装）
+// The host implements value resolution
+// (extend BaseValueResolver, implement resolveValueSource).
 const engine = ValidationEngine.create({
-  resolver,                 // 必須: ValueSource → 具体値
-  context: { db },          // 任意: カスタム演算子／レコードバリデータへ透過的に渡る
-  // customSuites: [ ... ]  // 任意: 組み込み38種へ追加注入（同 operatorKey は後勝ち）
+  resolver,
+  context: {
+    db,
+  },
 })
 
-// ルールは呼び出し側が DB からロード＆パース済みで渡す
-const parcel = await engine.execute({ rules, record })
+// The caller loads and parses the rules from the DB, then passes them in.
+const parcel = await engine.execute({
+  rules,
+  record,
+})
 
-parcel.hasValidationError()     // boolean（errored は含めない）
-parcel.hasEvaluationError()     // boolean（評価不能）
-parcel.extractViolatedRules()   // 違反ルール（errorMessage 付き）
-parcel.toPlainResult()          // シリアライズ可能なサマリ
+parcel.hasValidationError()     // boolean (does not include errored)
+parcel.hasEvaluationError()     // boolean (unevaluatable)
+parcel.extractViolatedRules()   // violated rules (with errorMessage)
+parcel.toPlainResult()          // a serializable summary
 ```
 
-The shape of one rule (`RuleInput`) passed to `execute()`:
+The shape of one rule passed to `execute()` (a `RuleInput`):
 
 ```jsonc
 {
-  "id": 1, "isActive": true, "executionOrder": 10,
-  "hasTriggerConditions": false, "errorMessage": "…",
+  "id": 1,
+  "isActive": true,
+  "executionOrder": 10,
+  "hasTriggerConditions": false,
+  "errorMessage": "…",
   "OriginObjectColumnId": 1010401,
-  "validationTree": { "operatorCategory": "FIELD", "operatorKey": "REQUIRED",
-    "subject": { "sourceValueType": "FORM_FIELD_REFERENCE", "value": { "sourceOriginObjectColumnId": 1010401 } },
-    "operands": {}, "options": {} },
+  "validationTree": {
+    "operatorCategory": "FIELD",
+    "operatorKey": "REQUIRED",
+    "subject": {
+      "sourceValueType": "FORM_FIELD_REFERENCE",
+      "value": { "sourceOriginObjectColumnId": 1010401 }
+    },
+    "operands": {},
+    "options": {}
+  },
   "triggerTree": null
 }
 ```
 
-## Main Public API
+### Custom operators
 
-| export | role |
-| :-- | :-- |
-| `ValidationEngine` | Public entry point. `create()` / `execute({ rules, record })` |
-| `ConditionEvaluator` / `SuiteRegistry` / `ValueSourceResolverDispatcher` | Evaluator / suite resolution / value-source resolution dispatch |
-| `ConditionSchemaValidator` (+ `SCHEMA_ERROR_CODE`) | **Structural validation** of condition-tree JSON (at save/load time) |
-| `ReferencedColumnIdsCollector` | Collects the column IDs a tree references (for change detection) |
-| `BaseConditionSuite` / `BaseCustomValidationSuite` | Base classes for operators (custom operators extend these) |
-| `BaseRecordValidator` | Base class for cross-field, record-level validation |
-| `BaseValueResolver` | The value-resolution contract (the host extends this) |
-| `ColumnValidationParcel` / `RuleValidationParcel` / `RecordValidationParcel` | Result parcels |
-| `builtinSuites` + each `XxxConditionSuite` | The 38 built-in operators |
-| `VALIDATION_TYPE` / `SOURCE_VALUE_TYPE` / `OPERATOR_CATEGORY` / `LOGICAL_OPERATOR_KEY` / … | Enum groups |
-
-See the individual documents for details: [Operators](./docs/operators.md) / [Schema validation](./docs/schema-validation.md) / [Referenced column collection](./docs/referenced-columns.md) / [Custom extensions](./docs/custom-extensions.md).
-
-## Extension
-
-**Custom operators** (sync/async, `context` available):
+A custom operator extends `BaseCustomValidationSuite`, may be sync or async, and can read
+the injected `context`.
 
 ```javascript
-import { BaseCustomValidationSuite } from '@openreachtech/mentsu-validation-rules'
+import {
+  BaseCustomValidationSuite,
+} from '@openreachtech/mentsu-validation-rules'
 
 class UniqueEmailConditionSuite extends BaseCustomValidationSuite {
-  get operatorKey () {
+  static get operatorKey () {
     return 'CUSTOM_UNIQUE_EMAIL'
   }
 
-  async evaluate ({ subject, context }) {
-    const duplicate = await context.db.findByEmail({ email: subject })
+  async evaluate ({
+    subject,
+    context,
+  }) {
+    const duplicate = await context.db.findByEmail({
+      email: subject,
+    })
 
     return duplicate === null
   }
 }
 
-const engine = ValidationEngine.create({ customSuites: [UniqueEmailConditionSuite], resolver, context: { db } })
+const engine = ValidationEngine.create({
+  customSuites: [
+    UniqueEmailConditionSuite,
+  ],
+  resolver,
+  context: {
+    db,
+  },
+})
 ```
 
-**Record-level validation** (`BaseRecordValidator` or a duck-typed `{ key, validate }`):
+### Record-level validation
+
+A record validator is a `BaseRecordValidator` subclass, or a duck-typed
+`{ key, validate }`, for checks that span several fields.
 
 ```javascript
 const engine = ValidationEngine.create({
@@ -100,189 +138,155 @@ const engine = ValidationEngine.create({
       key: 'startBeforeEnd',
       validate: ({ record }) => ({
         isValid: record.startAt <= record.endAt,
-        errorMessage: '開始日は終了日以前にしてください',
+        errorMessage: 'The start date must be on or before the end date',
       }),
     },
   ],
 })
 ```
 
-## Application Examples
+### A value-resolution adapter
 
-### JSON for a Moderately Complex Condition Tree
-
-A rule stating "**only when switching a product to published** (trigger), all of the following must hold": the name is required / the price is between `100` and `maxPrice` (another column) inclusive / the contact is **either email-formatted or a required phone number** (OR). In addition, the scheduled publish datetime must be **later than now** (compared against the dynamic value `NOW`).
-
-> Column mapping (example): `2001=name` / `2002=price` / `2003=maxPrice` / `2004=email` / `2005=phone` / `2006=publishAt` / `2010=status`
-
-```jsonc
-[
-  {
-    "id": 7001, "isActive": true, "executionOrder": 10,
-    "hasTriggerConditions": true,
-    "errorMessage": "公開に必要な項目を確認してください",
-    "OriginObjectColumnId": 2001,
-
-    // status が "PUBLISHED" のときだけ検証を発火
-    "triggerTree": {
-      "operatorCategory": "FIELD", "operatorKey": "EQUALS",
-      "subject":  { "sourceValueType": "FORM_FIELD_REFERENCE", "value": { "sourceOriginObjectColumnId": 2010 } },
-      "operands": { "comparison": { "sourceValueType": "FIXED_VALUE", "value": "PUBLISHED" } },
-      "options": {}
-    },
-
-    "validationTree": {
-      "operatorCategory": "LOGICAL", "operatorKey": "AND",
-      "children": [
-        { "operatorCategory": "FIELD", "operatorKey": "REQUIRED",
-          "subject": { "sourceValueType": "FORM_FIELD_REFERENCE", "value": { "sourceOriginObjectColumnId": 2001 } },
-          "operands": {}, "options": {} },
-
-        { "operatorCategory": "FIELD", "operatorKey": "BETWEEN",
-          "subject": { "sourceValueType": "FORM_FIELD_REFERENCE", "value": { "sourceOriginObjectColumnId": 2002 } },
-          "operands": {
-            "min": { "sourceValueType": "FIXED_VALUE", "value": 100 },
-            "max": { "sourceValueType": "FORM_FIELD_REFERENCE", "value": { "sourceOriginObjectColumnId": 2003 } }
-          },
-          "options": { "minInclusive": true, "maxInclusive": true } },
-
-        { "operatorCategory": "LOGICAL", "operatorKey": "OR",
-          "children": [
-            { "operatorCategory": "FIELD", "operatorKey": "REGEX",
-              "subject": { "sourceValueType": "FORM_FIELD_REFERENCE", "value": { "sourceOriginObjectColumnId": 2004 } },
-              "operands": { "pattern": { "sourceValueType": "FIXED_VALUE", "value": "^[^@\\s]+@[^@\\s]+$" } },
-              "options": { "flags": "u" } },
-            { "operatorCategory": "FIELD", "operatorKey": "REQUIRED",
-              "subject": { "sourceValueType": "FORM_FIELD_REFERENCE", "value": { "sourceOriginObjectColumnId": 2005 } },
-              "operands": {}, "options": {} }
-          ] }
-      ]
-    }
-  },
-
-  {
-    "id": 7002, "isActive": true, "executionOrder": 20,
-    "hasTriggerConditions": false,
-    "errorMessage": "公開予定日時は現在より後にしてください",
-    "OriginObjectColumnId": 2006,
-    "triggerTree": null,
-    "validationTree": {
-      "operatorCategory": "FIELD", "operatorKey": "GREATER_THAN_DATETIME",
-      "subject":  { "sourceValueType": "FORM_FIELD_REFERENCE", "value": { "sourceOriginObjectColumnId": 2006 } },
-      "operands": { "datetime": { "sourceValueType": "DYNAMIC_VALUE", "value": { "dynamicValueTypeKey": "NOW" } } },
-      "options": {}
-    }
-  }
-]
-```
-
-### Usage Image in an Application (Inside an API)
-
-**① Value-resolution adapter** (host-implemented) — turns a `ValueSource` into a concrete value taken from the record currently being validated, and so on. App-specific concerns such as the column-ID → field-name mapping and dynamic-value generation are contained here.
+The host implements how a `ValueSource` becomes a concrete value from the record being
+validated. Application-specific concerns — the column-id → field-name mapping, generating
+dynamic values — are confined here.
 
 ```javascript
-import { BaseValueResolver } from '@openreachtech/mentsu-validation-rules'
+import {
+  BaseValueResolver,
+} from '@openreachtech/mentsu-validation-rules'
 
 class RecordValueResolver extends BaseValueResolver {
-  constructor ({ record, columnFieldMap }) {
+  constructor ({
+    record,
+    columnFieldMap,
+  }) {
     super()
+
     this.record = record
     this.columnFieldMap = columnFieldMap
   }
 
-  static create ({ record, columnFieldMap }) {
-    return new this({ record, columnFieldMap })
+  static create ({
+    record,
+    columnFieldMap,
+  }) {
+    return new this({
+      record,
+      columnFieldMap,
+    })
   }
 
-  resolveValueSource ({ valueSource }) {
-    switch (valueSource.sourceValueType) {
-      case 'FIXED_VALUE':
-        return valueSource.value
-      case 'FORM_FIELD_REFERENCE': {
-        const field = this.columnFieldMap[valueSource.value.sourceOriginObjectColumnId]
-        return this.record[field] ?? null
-      }
-      case 'DYNAMIC_VALUE':
-        return valueSource.value.dynamicValueTypeKey === 'TODAY'
-          ? new Date().toISOString().slice(0, 10)
-          : new Date().toISOString()
-      default:
-        return null
+  resolveValueSource ({
+    valueSource,
+  }) {
+    if (valueSource.sourceValueType === 'FIXED_VALUE') {
+      return valueSource.value
     }
+
+    if (valueSource.sourceValueType === 'FORM_FIELD_REFERENCE') {
+      const field = this.columnFieldMap[valueSource.value.sourceOriginObjectColumnId]
+
+      return this.record[field]
+        ?? null
+    }
+
+    if (valueSource.sourceValueType === 'DYNAMIC_VALUE') {
+      return this.resolveDynamicValue({
+        valueSource,
+      })
+    }
+
+    return null
+  }
+
+  resolveDynamicValue ({
+    valueSource,
+  }) {
+    if (valueSource.value.dynamicValueTypeKey === 'TODAY') {
+      return new Date()
+        .toISOString()
+        .slice(0, 10)
+    }
+
+    return new Date()
+      .toISOString()
   }
 }
 ```
 
-**② API handler** (framework-agnostic; the same shape works for either Express or GraphQL) — loads the rules, evaluates them with the engine, and formats violations into a 422 response.
+## API
+
+| export | role |
+| :-- | :-- |
+| `ValidationEngine` | The public entry. `create()` / `execute({ rules, record })`. |
+| `ConditionEvaluator` / `SuiteRegistry` / `ValueSourceResolverDispatcher` | Evaluator / suite resolution / value-resolution dispatch. |
+| `ConditionSchemaValidator` (plus `SCHEMA_ERROR_CODE`) | **Structural** validation of the condition-tree JSON (on save / load). |
+| `ReferencedColumnIdsCollector` | Collects the column ids a tree references (for change detection). |
+| `BaseConditionSuite` / `BaseCustomValidationSuite` | Operator base classes (custom operators extend these). |
+| `BaseRecordValidator` | Base for cross-field, record-level validation. |
+| `BaseValueResolver` | The value-resolution contract (the host extends it). |
+| `ColumnValidationParcel` / `RuleValidationParcel` / `RecordValidationParcel` | Result parcels. |
+| `builtinSuites` plus each `XxxConditionSuite` | The 38 built-in operators. |
+| `VALIDATION_TYPE` / `SOURCE_VALUE_TYPE` / `OPERATOR_CATEGORY` / `LOGICAL_OPERATOR_KEY` / `DYNAMIC_VALUE_TYPE_KEY` / `DYNAMIC_VALUE_OFFSET_UNIT_KEY` / `REGEX` | The enums. |
+
+### Built-in operators
+
+`builtinSuites` bundles 38 operators, covering presence (`REQUIRED`, `EXISTS`), equality
+(`EQUALS`, `NOT_EQUALS`, `IN`, `NOT_IN`), numeric range (`MIN`, `MAX`, `BETWEEN`,
+`INTEGER`, `DECIMAL`), string (`CONTAINS`, `MIN_LENGTH`, `EXACT_LENGTH`), date / datetime
+(`MIN_DATE`, `BETWEEN_DATES`, `FUTURE_DATE`, `GREATER_THAN_DATETIME`, …), array / object
+existence, file (`FILE_SIZE`, `FILE_TYPE`), and format (`REGEX`, `URL`) checks. Each is a
+class under `lib/suites/builtin/`; pass extra ones through `create({ customSuites })`.
+
+## Dependency boundary
+
+- **The core is zero runtime dependency** — importing it pulls in nothing beyond the Node
+  standard library.
+- Directory-scanning suite auto-loading is isolated in the optional `./lib/adapters` entry
+  point (`DirectorySuiteLoader`), so the core stays dependency-free.
 
 ```javascript
-import { ValidationEngine } from '@openreachtech/mentsu-validation-rules'
+import {
+  DirectorySuiteLoader,
+} from '@openreachtech/mentsu-validation-rules/lib/adapters/index.js'
 
-async function validateProductForPublish ({ record, db }) {
-  const rules = await ruleStore.load({ objectId: PRODUCT_OBJECT_ID }) // アプリ側のロード層（JSON パース＋スキーマ検証済み）
-  const engine = ValidationEngine.create({
-    resolver: RecordValueResolver.create({ record, columnFieldMap: PRODUCT_COLUMN_FIELD_MAP }),
-    context: { db }, // カスタム演算子／レコードバリデータへ透過的に渡る
-  })
+const loader = DirectorySuiteLoader.create({
+  directoryPath,
+})
 
-  const parcel = await engine.execute({ rules, record })
+const suites = await loader.loadSuites()
 
-  // 設定ミス由来（未知演算子・解決失敗）は errored として分離される。監視へ回す。
-  if (parcel.hasEvaluationError()) {
-    logger.error('validation misconfiguration', parcel.extractErroredRules())
-  }
-
-  const { violated, violatedRecords } = parcel.toPlainResult()
-  return {
-    isValid: !parcel.hasValidationError(),
-    errors: [
-      ...violated.map(it => ({ field: PRODUCT_COLUMN_FIELD_MAP[it.originObjectColumnId], message: it.errorMessage })),
-      ...violatedRecords.map(it => ({ field: it.key, message: it.errorMessage })),
-    ],
-  }
-}
-
-// Express の例
-app.post('/products/:id/publish', async (req, res) => {
-  const { isValid, errors } = await validateProductForPublish({ record: req.body, db })
-
-  if (!isValid) {
-    return res.status(422).json({ errors })
-  }
-
-  const saved = await productRepository.save(req.body)
-  return res.status(200).json(saved)
+const engine = ValidationEngine.create({
+  suites,
+  resolver,
 })
 ```
 
-> Key point: the package **never throws**, so no try/catch is needed on the API side. Business violations (`hasValidationError()` / `violated`) and **configuration mistakes (`hasEvaluationError()` / errored)** are kept as separate roles (fail-safe by default; use `treatErrorAsViolation: true` for strict operation).
+## Contribution
 
-## Dependency Boundary
+Bug reports, feature requests, and code contributions are welcome.
 
-- **The core (`src/`) has zero external runtime dependencies.** Importing it brings in no runtime dependency beyond the Node standard library.
-- Automatic suite loading via directory traversal is isolated in the optional `./adapters` adapter (`DirectorySuiteLoader`).
+Feel free to contact us through GitHub Issues.
 
-```
-exports
-├── "."          → src/index.js        （コア。無依存）
-└── "./adapters" → adapters/index.js   （任意。ディレクトリ走査ローダ）
-```
-
-```javascript
-import { DirectorySuiteLoader } from '@openreachtech/mentsu-validation-rules/lib/adapters/index.js'
-
-const suites = await DirectorySuiteLoader.create({ directoryPath }).loadSuites()
-const engine = ValidationEngine.create({ suites, resolver })
-```
-
-## Development
-
-```bash
+```sh
+git clone https://github.com/openreachtech/mentsu-validation-rules.git
+cd mentsu-validation-rules
 npm install
-npm test        # jest（--experimental-vm-modules）
-npm run lint    # eslint（@openreachtech/eslint-config）
+npm run lint
+npm test
 ```
 
-## Status
+## License
 
-The package itself (core + 38 built-in operators + schema validation + referenced-column collection + custom extensions + public API / optional adapter) is implemented and tested. Conversion from the legacy schema to the new schema (`LegacyConditionConverter`) is an app-specific migration process and is not included in this package; it lives as a reference implementation under [`migration/`](./migration/) (excluded from `npm pack`, on a separate branch). App-side integration, DB migration, and front-end integration are follow-up work on the crm-kit side itself.
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/mentsu-value-inspector/README.md
+++ b/lib/docs/mentsu-value-inspector/README.md
@@ -1,0 +1,89 @@
+# @openreachtech/mentsu-value-inspector
+
+Readable predicate methods for inspecting JavaScript values (numbers, integers, dates), backed by pluggable normalizers.
+
+Each inspector wraps a single value and exposes self-describing checks — `isNumber()`, `isPositiveNumberLike()`, `isDate()`, and so on — so scattered, error-prone type checks can be replaced with a consistent API.
+
+## Concept
+
+Inspectors provide two families of predicates:
+
+- **Strict** predicates check the raw JavaScript value as-is (`isNumber()`, `isInteger()`, `isDate()`).
+- **`*Like`** predicates first normalize the value, so loosely-typed inputs such as numeric strings are accepted (`isNumberLike()`, `isIntegerLike()`, `isDateLike()`).
+
+Normalization is delegated to a normalizer from [`@openreachtech/mentsu-value-normalizer`](https://github.com/openreachtech/mentsu-value-normalizer). A default normalizer is created per inspector, but you may inject your own.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/mentsu-value-inspector
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+```js
+import {
+  NumberValueInspector,
+  IntegerValueInspector,
+  DateValueInspector,
+} from '@openreachtech/mentsu-value-inspector'
+
+// Numbers: strict vs. *Like
+const numberInspector = NumberValueInspector.create({ value: '42' })
+
+numberInspector.isNumber() // false (the raw value is a string)
+numberInspector.isNumberLike() // true  (the string is normalized to a number)
+
+NumberValueInspector.create({ value: -3 }).isNegativeNumber() // true
+NumberValueInspector.create({ value: '1.5' }).isPositiveNumberLike() // true
+
+// Integers
+const integerInspector = IntegerValueInspector.create({ value: '10' })
+
+integerInspector.isInteger() // false (the raw value is a string)
+integerInspector.isIntegerLike() // true
+IntegerValueInspector.create({ value: 10.5 }).isSafeInteger() // false
+
+// Dates
+const dateInspector = DateValueInspector.create({ value: '2020-01-01' })
+
+dateInspector.isDate() // false (the raw value is a string)
+dateInspector.isDateLike() // true
+DateValueInspector.create({ value: new Date('invalid') }).isDate() // false
+```
+
+## API
+
+See the [API reference](https://github.com/openreachtech/mentsu-value-inspector/blob/main/docs/en/api/index.md).
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/mentsu-value-inspector.git
+cd mentsu-value-inspector
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/mentsu-value-normalizer/README.md
+++ b/lib/docs/mentsu-value-normalizer/README.md
@@ -1,0 +1,206 @@
+# Mentsu Value Normalizer
+
+Normalize loosely-typed input values into a canonical form, guarding on the value's runtime type before conversion.
+
+## Overview
+
+`BaseValueNormalizer` wraps a raw value together with the set of runtime types it is
+willing to accept. When you ask it to normalize, it first checks the value's type against
+the acceptable types, then converts it. If the value is not acceptable — or cannot be
+converted — normalization yields `null` instead of throwing.
+
+The package ships ready-made normalizers (`NumberValueNormalizer`,
+`IntegerValueNormalizer`, `DateValueNormalizer`), and `BaseValueNormalizer` is designed to
+be extended so you can implement your own.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/mentsu-value-normalizer
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+### Normalize with a provided normalizer
+
+Each concrete normalizer declares its own acceptable types. `NumberValueNormalizer`
+accepts `number` and `bigint`, and converts them with `Number()`.
+
+```js
+import { NumberValueNormalizer } from '@openreachtech/mentsu-value-normalizer'
+
+const numberNormalizer = NumberValueNormalizer.create({
+  value: 42n,
+})
+
+const normalizedNumber = numberNormalizer.normalizeValue() // 42
+```
+
+When the value's type is not among the acceptable types, normalization returns `null` —
+even if the value could otherwise be converted.
+
+```js
+import { NumberValueNormalizer } from '@openreachtech/mentsu-value-normalizer'
+
+// A string is not an acceptable type for NumberValueNormalizer.
+const rejectedNumber = NumberValueNormalizer.create({
+  value: '42',
+})
+  .normalizeValue() // null
+```
+
+`DateValueNormalizer` accepts `string` and `number`, and converts them with `new Date()`.
+
+```js
+import { DateValueNormalizer } from '@openreachtech/mentsu-value-normalizer'
+
+const dateNormalizer = DateValueNormalizer.create({
+  value: '2026-07-08',
+})
+
+const normalizedDate = dateNormalizer.normalizeValue() // Date instance
+```
+
+### Bind a custom set of acceptable types
+
+Use `.from()` to derive a normalizer bound to a different set of acceptable types. Here we
+also accept `string`, so a numeric string passes the type guard and gets converted.
+
+```js
+import {
+  NumberValueNormalizer,
+  ACCEPTABLE_TYPE,
+} from '@openreachtech/mentsu-value-normalizer'
+
+const LooseNumberNormalizer = NumberValueNormalizer.from([
+  ACCEPTABLE_TYPE.NUMBER,
+  ACCEPTABLE_TYPE.BIGINT,
+  ACCEPTABLE_TYPE.STRING,
+])
+
+const normalizedNumber = LooseNumberNormalizer.create({
+  value: '42',
+})
+  .normalizeValue() // 42
+```
+
+### Implement your own normalizer
+
+Extend `BaseValueNormalizer` and override the acceptable types plus the conversion logic.
+The three members below form the implementation contract:
+
+- `static get acceptableTypes ()` — the runtime types this normalizer accepts.
+- `canNormalize ()` — whether the current value can be normalized.
+- `toNormalizedValue ()` — how to convert the value once it is normalizable.
+
+```js
+import {
+  BaseValueNormalizer,
+  ACCEPTABLE_TYPE,
+} from '@openreachtech/mentsu-value-normalizer'
+
+class UpperCaseValueNormalizer extends BaseValueNormalizer {
+  /** @override */
+  static get acceptableTypes () {
+    return [
+      ACCEPTABLE_TYPE.STRING,
+    ]
+  }
+
+  /** @override */
+  canNormalize () {
+    return this.isAcceptableTypeValue()
+  }
+
+  /** @override */
+  toNormalizedValue () {
+    if (!this.canNormalize()) {
+      return null
+    }
+
+    return String(this.value)
+      .toUpperCase()
+  }
+}
+
+const normalizedText = UpperCaseValueNormalizer.create({
+  value: 'hello',
+})
+  .normalizeValue() // 'HELLO'
+```
+
+## API
+
+Class members are written with the following notation.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+### BaseValueNormalizer
+
+Abstract base class. Use it directly by extending it, or use one of the provided
+normalizers below.
+
+| member | description |
+| :-- | :-- |
+| `.create({ value, acceptableTypes })` | Factory method. Creates an instance for `value`. `acceptableTypes` defaults to the class's `acceptableTypes`. |
+| `.from(types)` | Derives a subclass whose `acceptableTypes` is bound to `types`. Calling it again with the same `types` array reference returns the same subclass. |
+| `.get:acceptableTypes` | The runtime types this normalizer accepts. Abstract on the base class — override it in a subclass (or bind it via `.from()`). |
+| `#normalizeValue()` | Returns the normalized value, or `null` when the value is not acceptable or cannot be converted. Repeated calls on the same instance reuse the first result. |
+| `#toNormalizedValue()` | Converts the value to its normalized form. Abstract — override it in a subclass. |
+| `#canNormalize()` | Whether the current value can be normalized. Abstract — override it in a subclass. |
+| `#isAcceptableTypeValue()` | Whether the value's runtime type is among the acceptable types. Override it to customize the type guard. |
+
+### Provided normalizers
+
+| class | acceptable types | normalized value |
+| :-- | :-- | :-- |
+| `NumberValueNormalizer` | `number`, `bigint` | `Number(value)` |
+| `IntegerValueNormalizer` | `number`, `bigint` | `Number(value)`, only when it is an integer |
+| `DateValueNormalizer` | `string`, `number` | `new Date(value)` |
+
+### ACCEPTABLE_TYPE
+
+A map of `Symbol` constants used to declare acceptable types:
+`STRING`, `NUMBER`, `BIGINT`, `BOOLEAN`, `SYMBOL`, `UNDEFINED`, `OBJECT`, `FUNCTION`,
+`NULL`.
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/mentsu-value-normalizer.git
+cd mentsu-value-normalizer
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/renchan-elasticsearch/README.md
+++ b/lib/docs/renchan-elasticsearch/README.md
@@ -1,0 +1,124 @@
+# @openreachtech/renchan-elasticsearch
+
+An Elasticsearch client module for the Renchan stack.
+
+You define one `Index` class per Elasticsearch index and one `Document` class that
+declares its schema, then drive the index through high-level methods —
+`createIndex()`, `insertDocuments()`, `searchDocuments()`, and more — without
+hand-writing REST requests.
+
+## Table of contents
+
+- [Concept](#concept)
+- [Installation](#installation)
+- [Features](#features)
+- [API](#api)
+- [Contribution](#contribution)
+- [License](#license)
+- [Developer](#developer)
+- [Copyright](#copyright)
+
+## Concept
+
+The module is organized around two classes you extend:
+
+- **`BaseIndex`** — one subclass per Elasticsearch index. It carries the index name,
+  the connection config, and the document constructor, and exposes the operations
+  you call (`createIndex`, `insertDocuments`, `searchDocuments`, …).
+- **`BaseDocument`** — one subclass per index. It declares the field `schema` (built
+  from scalar types such as `Text`, `Keyword`, and `Datetime`) and the Elasticsearch
+  mappings for those fields.
+
+Each operation is fulfilled by a request pipeline (`Payload` → `Launcher` →
+`Capsule`) built on [`@openreachtech/mentsu-rocket-client`](https://github.com/openreachtech/mentsu-rocket-client),
+so every call returns a `Capsule` whose `.body` holds the parsed Elasticsearch
+response. Search queries are written in a camelCase **Query DSL** (and aggregations
+in an **Aggregations DSL**) that is reified into Elasticsearch JSON for you.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+This package is published to GitHub Packages under the `@openreachtech` scope. Before
+installing, the following two steps are required:
+
+1. Add the registry to your project's `.npmrc`:
+
+   ```
+   @openreachtech:registry=https://npm.pkg.github.com
+   ```
+
+2. Authenticate with `npm login`:
+
+   ```sh
+   npm login --registry https://npm.pkg.github.com
+   ```
+
+Then install:
+
+```sh
+npm install @openreachtech/renchan-elasticsearch
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Features
+
+### (1) Defining an Index and a Document
+
+Subclass `BaseIndex` and `BaseDocument` to model an Elasticsearch index and its
+document schema.
+
+[Defining an Index and a Document](https://github.com/openreachtech/renchan-elasticsearch/blob/main/docs/en/features/defining-index.md)
+
+### (2) Managing Indices
+
+Create and delete indices from the definition your `Document` class declares.
+
+[Managing Indices](https://github.com/openreachtech/renchan-elasticsearch/blob/main/docs/en/features/managing-indices.md)
+
+### (3) Writing Documents
+
+Insert, update, put (upsert), and delete documents in bulk.
+
+[Writing Documents](https://github.com/openreachtech/renchan-elasticsearch/blob/main/docs/en/features/writing-documents.md)
+
+### (4) Reading and Searching Documents
+
+Check existence, fetch by UUID, and search with the Query DSL and Aggregations DSL.
+
+[Reading and Searching Documents](https://github.com/openreachtech/renchan-elasticsearch/blob/main/docs/en/features/reading-documents.md)
+
+## API
+
+See the API reference for the classes you extend and the members they expose.
+
+[API Reference](https://github.com/openreachtech/renchan-elasticsearch/blob/main/docs/en/api/index.md)
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/renchan-elasticsearch.git
+cd renchan-elasticsearch
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/renchan-env/README.md
+++ b/lib/docs/renchan-env/README.md
@@ -15,14 +15,6 @@
   | Node.js | ^20.19.2 |
   | npm | ^10.5.2 |
 
-* Create a `.npmrc` file in the root directory of your project and add any necessary configurations. This might be required for installing certain npm packages.
-
-* Please add the following line to your `.npmrc` file.
-
-  ```
-  @openreachtech:registry=https://npm.pkg.github.com
-  ```
-
 * You can install `renchan-env` with the following command:
 
   ```
@@ -117,7 +109,7 @@ console.log(env.UNKNOWN_KEY) // throws 'environment variable is not defined [UNK
 
 ## License
 
-This project is released under the MIT License.<br>
+This project is released under the Apache License 2.0.<br>
 See [here](./LICENSE)
 
 ## Contribution

--- a/lib/docs/renchan-funnel/README.md
+++ b/lib/docs/renchan-funnel/README.md
@@ -1,0 +1,295 @@
+# @openreachtech/renchan-funnel
+
+A funnel (workflow-automation) engine that reacts to database change events.
+
+`@openreachtech/renchan-funnel` consumes Debezium CDC change messages off Kafka, evaluates them against user-defined *funnels* (trigger conditions stored in the database), and dispatches the configured actions as background jobs when a change matches. A scheduled (cron) trigger path is also provided. It is a library of abstract base classes: the consuming application supplies its own Sequelize models and job dispatchers by subclassing.
+
+## Concept
+
+### The domain model
+
+- **Funnel** — a stored automation rule. It targets an *origin object category* (a logical entity such as `USER` that may span several source tables), carries an ordered set of trigger conditions and actions, and is toggled by an active flag. Each funnel owns an *id hash*, which is also the name of its own Kafka topic.
+- **Trigger** — what makes a funnel fire. Categories are `record_created`, `record_updated`, `record_deleted` (all CDC-driven) and `scheduled` (cron-driven).
+- **Trigger condition** — compares a left-hand value against a right-hand value using an operator (`EQUALS`, `NOT_EQUALS`, `CONTAINS`, `NOT_CONTAINS`, `IN`, `NOT_IN`, `IS_NULL`, `IS_NOT_NULL`, `GREATER_THAN_OR_EQUAL`), combined with logical operators. Each operator is one small strategy class — a *trigger condition suite* extending `BaseFunnelTriggerSuite`.
+- **Source value type** — where each side of a condition or action value comes from: `FIXED_VALUE`, `DYNAMIC_VALUE` (time-relative, e.g. "now" / "today", optionally offset by days / hours / minutes), `NEW_VALUE` (post-change), `OLD_VALUE` (pre-change), or `FIELD_REFERENCE` (a field on the origin object record, resolved from the database).
+- **Action** — what a funnel does when it fires. Each action is turned into a background-job payload by a `BaseFunnelActionPayloadGenerator` and dispatched through a job dispatcher resolved by the action's type.
+
+### The two-stage Kafka pipeline
+
+1. **Message filter layer** — a `BaseDebeziumEachBatchConsumer` watches one source *table*. For each batch it matches every change message against the funnels targeting that table, groups the messages by the funnel they matched, and re-publishes each group unchanged to that funnel's own topic. This stage only routes; it does not execute.
+2. **Execution layer** — a `BaseFunnelConsumer` subscribes to a single funnel's topic and drives a `BaseFunnelExecutor`, which records the execution and dispatches one background job per funnel action.
+
+A separate **schedule daemon** covers `scheduled` funnels by evaluating cron expressions and dispatching the same action jobs on time.
+
+The consuming application binds the library to its own world through a single `BaseFunnelModelsProvider` subclass — the library imports no model directly.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/renchan-funnel
+```
+
+When using GitHub Packages (the `@openreachtech` scope), the following two items are
+required:
+
+1. Add the registry to your project's `.npmrc`:
+
+   ```
+   @openreachtech:registry=https://npm.pkg.github.com
+   ```
+
+2. Authenticate with `npm login`:
+
+   ```sh
+   npm login --registry https://npm.pkg.github.com
+   ```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+This package builds on [`@openreachtech/renchan-kafka`](https://github.com/openreachtech/renchan-kafka) for its Kafka consumer/producer framework, and expects the consuming application to provide Sequelize models and a background-job transport.
+
+## Usage
+
+Wiring a funnel pipeline into an application takes four pieces.
+
+### 1. Models provider
+
+Bind the library's model names to your own Sequelize models. Override one static getter per model the base declares; the library reaches every table through this single indirection point.
+
+```js
+import {
+  BaseFunnelModelsProvider,
+} from '@openreachtech/renchan-funnel'
+
+import Funnel from '../sequelize/models/Funnel.js'
+import FunnelAction from '../sequelize/models/FunnelAction.js'
+import FunnelExecution from '../sequelize/models/FunnelExecution.js'
+import OriginObjectCategory from '../sequelize/models/OriginObjectCategory.js'
+// ...import the rest of your models
+
+export default class FunnelModelsProvider extends BaseFunnelModelsProvider {
+  static get FunnelModel () {
+    return Funnel
+  }
+
+  static get FunnelActionModel () {
+    return FunnelAction
+  }
+
+  static get FunnelExecutionModel () {
+    return FunnelExecution
+  }
+
+  static get OriginObjectCategoryModel () {
+    return OriginObjectCategory
+  }
+
+  // ...override every model getter the base declares
+}
+```
+
+### 2. Stage 1 — filter / route consumer (one per watched table)
+
+```js
+import {
+  BaseDebeziumEachBatchConsumer,
+} from '@openreachtech/renchan-funnel'
+
+import FunnelModelsProvider from '../tools/FunnelModelsProvider.js'
+
+export default class UserBasicDebeziumEachBatchConsumer extends BaseDebeziumEachBatchConsumer {
+  static get config () {
+    return {
+      groupId: 'user_basics-funnel-group',
+    }
+  }
+
+  static get errorCodeHash () {
+    return {}
+  }
+
+  static get tableName () {
+    return 'user_basics'
+  }
+
+  static get debeziumTopicPrefix () {
+    return `${env.KAFKA_DEBEZIUM_TOPIC_PREFIX}.${env.DATABASE_NAME}`
+  }
+
+  static get FunnelModelsProviderCtor () {
+    return FunnelModelsProvider
+  }
+}
+```
+
+### 3. Stage 2 — executor + execution consumer
+
+The executor declares which origin object category it serves and which job dispatcher handles each action type. The consumer binds one funnel (by its id hash) to that executor.
+
+```js
+import {
+  BaseFunnelExecutor,
+  BaseFunnelConsumer,
+} from '@openreachtech/renchan-funnel'
+
+import FunnelModelsProvider from '../tools/FunnelModelsProvider.js'
+
+export class UserFunnelExecutor extends BaseFunnelExecutor {
+  static get targetOriginObjectCategoryId () {
+    return ORIGIN_OBJECT_CATEGORY.USER.ID
+  }
+
+  static get funnelJobDispatcherCtorHash () {
+    // keyed by the action's actionType
+    return {
+      [ACTION_TYPE.SEND_EMAIL]: SendEmailJobDispatcher,
+    }
+  }
+}
+
+export class SendWelcomeExecutionFunnelConsumer extends BaseFunnelConsumer {
+  static get funnelIdHash () {
+    return FUNNEL_ID_HASH.SEND_EMAIL_TO_USER_WHEN_USER_IS_CREATED
+  }
+
+  static get FunnelExecutorCtor () {
+    return UserFunnelExecutor
+  }
+
+  static get FunnelModelsProviderCtor () {
+    return FunnelModelsProvider
+  }
+
+  static async resolveSystemUserId () {
+    return Number(env.SYSTEM_USER_ID)
+  }
+}
+```
+
+Both consumers are booted by your renchan-kafka engine, which passes `{ engine, kafkaClient }` into each consumer's `.createAsync()`.
+
+### 4. Scheduled funnels daemon
+
+For `scheduled` funnels, run a daemon that evaluates cron expressions and dispatches action jobs on time.
+
+```js
+import {
+  ScheduleFunnelDaemon,
+} from '@openreachtech/renchan-funnel'
+
+import ScheduleFunnelsExecutor from '../executors/ScheduleFunnelsExecutor.js'
+import FunnelModelsProvider from '../tools/FunnelModelsProvider.js'
+
+const funnelModelsProvider = await FunnelModelsProvider.createAsync()
+
+const executor = await ScheduleFunnelsExecutor.createAsync({
+  funnelModelsProvider,
+  systemUserId: Number(env.SYSTEM_USER_ID),
+})
+
+ScheduleFunnelDaemon.create({
+  executor,
+})
+  .start()
+```
+
+Abstract members that are not overridden throw at startup with the missing member's name (`ConcreteMemberNotFoundFunnelError`), so a mis-wired pipeline fails loudly rather than silently.
+
+## API
+
+Class members are written with the following notation.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+Members marked ⚠ are abstract — the consuming application must override them.
+
+### `BaseFunnelModelsProvider`
+
+Binds the library's model names to the application's Sequelize models.
+
+- `.createAsync()` / `.create()` — build a provider.
+- ⚠ `.get:FunnelModel`, ⚠ `.get:FunnelActionModel`, ⚠ `.get:FunnelExecutionModel`, ⚠ `.get:OriginObjectCategoryModel`, and the remaining model getters — one per table the library reads or writes. Each is also served as an instance getter of the same name.
+
+### `BaseDebeziumEachBatchConsumer` (stage 1)
+
+Watches one table and routes matched messages to per-funnel topics.
+
+- `.createAsync({ engine, kafkaClient })` / `.create()`
+- ⚠ `.get:tableName`, ⚠ `.get:debeziumTopicPrefix`, ⚠ `.get:FunnelModelsProviderCtor`
+- override `.get:config` (Kafka `groupId`), `.get:errorCodeHash`
+- `#onEachBatch()` — implemented; performs matching and routing.
+
+### `BaseFunnelConsumer` (stage 2)
+
+Serves a single funnel's topic.
+
+- `.createAsync({ engine, kafkaClient })` / `.create()`
+- ⚠ `.get:funnelIdHash`, ⚠ `.get:FunnelExecutorCtor`, ⚠ `.get:FunnelModelsProviderCtor`, ⚠ `.resolveSystemUserId()`
+- provided: `.get:MessageDeserializerCtor`, `.get:MessageKeyCtor`, `.get:MessageValueCtor`, `#onEachBatch()`
+
+### `BaseFunnelExecutor`
+
+Records executions and dispatches one job per action.
+
+- `.createAsync({ funnelModelsProvider, originObjectColumns, systemUserId })` / `.create()`
+- ⚠ `.get:targetOriginObjectCategoryId`, ⚠ `.get:funnelJobDispatcherCtorHash`
+- optional override: `.get:fallbackFunnelJobDispatcherCtor`, `.get:ActionPayloadGeneratorCtor`, `#get:valueSuiteClasses`
+- `#executeTriggerFunnels({ debeziumMessageValues, targetFunnel })` — the main entry point.
+
+### `BaseFunnelTriggerSuite`
+
+One strategy class per trigger operator.
+
+- `.create()`
+- ⚠ `#get:operatorKey`, ⚠ `#isPassTrigger({ leftHand, rightHand })`
+- provided: `#evaluate()`, `#extractValue()`
+
+### Other extension points
+
+- `BaseFunnelValueRetrieverSuite` — ⚠ `.get:sourceValueTypeKey`, ⚠ `#retrieveValue()`
+- `BaseFunnelActionPayloadGenerator` — ⚠ `.get:actionCategoryKey`, ⚠ `#generatePayload()`
+- `BaseScheduleFunnelsExecutor` — ⚠ `.loadJobDispatcherCtors()`
+- `BaseCustomFunnelActionExecutor` — ⚠ `.get:ExecutionLogRegistererCtor`, ⚠ `#saveEntitiesIntoParcel()`
+
+### Also exported
+
+Constants (`FUNNEL_STATUS`, `FUNNEL_TRIGGER_CATEGORY`, `FUNNEL_TRIGGER_OPERATOR_KEY`, `SOURCE_VALUE_TYPE`, `DYNAMIC_VALUE_TYPE_KEY`, `DYNAMIC_VALUE_OFFSET_UNIT_KEY`, `LOGICAL_OPERATOR_KEY`, and more); the nine concrete trigger condition suites; dynamic / offset value providers; save parcels (`NewEntitySaveParcel`, `UpdateEntitySaveParcel`, `DeleteEntitySaveParcel`); producers (`FunnelBufferProducer`, `BaseAppBufferProducer`); extractors (`FunnelExtractor`, `FunnelActionValueExtractor`, `DebeziumMessageValueExtractor`, `FunnelFieldReferencePathExtractor`); and the `FunnelError` family.
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/renchan-funnel.git
+cd renchan-funnel
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/renchan-job-bullmq/README.md
+++ b/lib/docs/renchan-job-bullmq/README.md
@@ -1,0 +1,435 @@
+# @openreachtech/renchan-job-bullmq
+
+Renchan job modules wrapping BullMQ.
+
+`@openreachtech/renchan-job-bullmq` is a background-job framework built on [BullMQ](https://docs.bullmq.io/) (Redis-backed queues). It provides an opinionated class hierarchy the consuming application extends — schema-validated job bodies, per-job loggers, a worker daemon with graceful shutdown, and cron / interval repeatable schedules — around the BullMQ `Queue` and `Worker` primitives.
+
+## Concept
+
+### The per-job triple
+
+Every job is described by three classes that share one `Manifest`.
+
+- **Manifest** (`BaseJobManifest`) — the single source of truth for a job's identity: its `jobName` (also the BullMQ queue name) and its `bodySchema`. Worker, Dispatcher, and Scheduler all reference the same manifest, so the queue name and body schema stay consistent.
+- **Worker** (`BaseJobWorker`) — the consumer side. Wraps a BullMQ `Worker`, listens on the manifest's `jobName`, validates and normalizes the payload, and runs your `executeJob()`.
+- **Dispatcher** (`BaseJobDispatcher`) — the producer side. Wraps a BullMQ `Queue`; `dispatchJob({ body })` validates the body against the manifest schema, enqueues it, and returns a `DispatcherResponse`.
+
+### Process-level infrastructure
+
+- **Engine** (`BaseJobEngine`) — per-process configuration and dependency-injection hub: where workers (and optionally schedulers) live, the Redis connection, the shared `Share`, the logger pools, and the error-code hash exposed everywhere as `.Error`.
+- **Context / Share** (`BaseJobContext` / `BaseJobShare`) — `Context` is built fresh per job execution (carries `executedAt` / `now` and forwards the engine, config, env, logger); `Share` is built once per process for shared singletons. Both may be empty subclasses.
+- **JobWorkersDaemon** — the long-running worker process. It builds the engine, auto-discovers every worker under the configured path, starts them, and installs `SIGINT` / `SIGTERM` handlers for graceful shutdown.
+- **Scheduler service + schedulers + schedules** — `BaseJobSchedulerService` registers repeatable jobs; `BaseCronJobScheduler` / `BaseIntervalJobScheduler` wrap a queue's job-scheduler API; `CronSchedule` / `IntervalSchedule` validate and denormalize a schedule spec into BullMQ's repeat options.
+
+Jobs are discovered by convention: the daemon and the scheduler service recursively scan the Engine's configured directories and pick up every default-exported subclass, so a job is "registered" simply by placing its file under the configured path.
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/renchan-job-bullmq
+```
+
+When using GitHub Packages (the `@openreachtech` scope), the following two items are
+required:
+
+1. Add the registry to your project's `.npmrc`:
+
+   ```
+   @openreachtech:registry=https://npm.pkg.github.com
+   ```
+
+2. Authenticate with `npm login`:
+
+   ```sh
+   npm login --registry https://npm.pkg.github.com
+   ```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+A running Redis instance is required. The examples below read `REDIS_HOST` / `REDIS_PORT` from the environment.
+
+## Usage
+
+Defining and running a job takes a Manifest / Worker / Dispatcher triple, an Engine, and the worker daemon.
+
+### 1. Define a job (Manifest + Worker + Dispatcher)
+
+```js
+// AlphaJobManifest.js
+import {
+  ScalarHash,
+} from '@openreachtech/mentsu-schema'
+
+import {
+  BaseJobManifest,
+} from '@openreachtech/renchan-job-bullmq'
+
+const {
+  BigNum,
+  Datetime,
+  Integer,
+  Text,
+} = ScalarHash
+
+export default class AlphaJobManifest extends BaseJobManifest {
+  static get jobName () {
+    return 'alpha'
+  }
+
+  static get bodySchema () {
+    return {
+      customerId: Integer,
+      amount: BigNum,
+      confirmedAt: Datetime,
+      transactionHash: Text,
+    }
+  }
+}
+```
+
+```js
+// AlphaJobWorker.js
+import {
+  BaseJobWorker,
+} from '@openreachtech/renchan-job-bullmq'
+
+import AlphaJobManifest from './AlphaJobManifest.js'
+
+export default class AlphaJobWorker extends BaseJobWorker {
+  static get ManifestCtor () {
+    return AlphaJobManifest
+  }
+
+  /** @override */
+  async executeJob ({ body, context, parcel }) {
+    this.timber.log(`[${this.Ctor.jobName}] body:`, body)
+
+    // The return value is stored in Redis — keep it minimal.
+    return {
+      executedAt: context.now.toISOString(),
+    }
+  }
+
+  /** @override */
+  onJobCompleted ({ jobModel, result, previousStatus }) {}
+
+  /** @override */
+  onJobFailed ({ jobModel, error, previousStatus }) {}
+
+  /** @override */
+  onJobProgress ({ jobModel, progress }) {}
+
+  /** @override */
+  onWorkerError ({ error }) {}
+}
+```
+
+```js
+// AlphaJobDispatcher.js
+import {
+  BaseJobDispatcher,
+} from '@openreachtech/renchan-job-bullmq'
+
+import SampleJobEngine from '../SampleJobEngine.js'
+import AlphaJobManifest from './AlphaJobManifest.js'
+
+// An intermediate app base dispatcher binds the engine once.
+class AppBaseJobDispatcher extends BaseJobDispatcher {
+  static get EngineCtor () {
+    return SampleJobEngine
+  }
+}
+
+export default class AlphaJobDispatcher extends AppBaseJobDispatcher {
+  static get ManifestCtor () {
+    return AlphaJobManifest
+  }
+}
+```
+
+### 2. Engine (+ Share + Context)
+
+```js
+import {
+  BaseJobEngine,
+  BaseJobShare,
+  BaseJobContext,
+} from '@openreachtech/renchan-job-bullmq'
+
+class SampleJobShare extends BaseJobShare {}
+
+class SampleJobContext extends BaseJobContext {}
+
+export default class SampleJobEngine extends BaseJobEngine {
+  static get config () {
+    return {
+      workersPath: rootPath.to('app/jobs'), // directory scanned for workers
+      // schedulersPath: rootPath.to('app/jobs'), // add when using schedulers
+      redisConfig: {
+        host: env.REDIS_HOST,
+        port: Number(env.REDIS_PORT),
+      },
+    }
+  }
+
+  static get ShareCtor () {
+    return SampleJobShare
+  }
+
+  static get ContextCtor () {
+    return SampleJobContext
+  }
+
+  static get standardErrorCodeHash () {
+    return {
+      Unknown: '100.X000.001',
+      InvalidRequest: '103.X000.001',
+      Database: '104.X000.001',
+    }
+  }
+
+  static get savingLogFilePath () {
+    return 'logs/'
+  }
+}
+```
+
+`InvalidRequest` is load-bearing: `dispatchJob()` throws `this.Error.InvalidRequest` when a body fails schema validation.
+
+### 3. Enqueue a job
+
+```js
+import BigNumber from 'bignumber.js'
+
+import AlphaJobDispatcher from '../app/jobs/alpha/AlphaJobDispatcher.js'
+
+const dispatcher = await AlphaJobDispatcher.createAsync() // engine auto-created
+
+const response = await dispatcher.dispatchJob({
+  body: {
+    customerId: 100001,
+    amount: new BigNumber('0.123456789'),
+    confirmedAt: new Date('2026-05-20T12:00:00.000Z'),
+    transactionHash: '0x...',
+  },
+})
+
+if (response.hasError()) {
+  // response.errorMessage
+}
+
+if (response.hasResponse()) {
+  // response.createDispatchedAt()?.toISOString()
+}
+
+await dispatcher.teardown()
+```
+
+### 4. Start the worker daemon
+
+```js
+import {
+  JobWorkersDaemon,
+} from '@openreachtech/renchan-job-bullmq'
+
+import SampleJobEngine from '../app/SampleJobEngine.js'
+
+// Loads every worker under workersPath; SIGINT / SIGTERM trigger graceful shutdown.
+const daemon = await JobWorkersDaemon.createAsync({
+  EngineCtor: SampleJobEngine,
+})
+
+const workers = await daemon.startDaemon()
+```
+
+### 5. Scheduled (cron / interval) jobs
+
+A scheduler binds a manifest to a cron or interval schedule; the scheduler service registers them. The worker daemon must be running to execute the jobs — the service only upserts the repeatable jobs in Redis.
+
+```js
+// BetaCronJobScheduler.js
+import {
+  BaseCronJobScheduler,
+} from '@openreachtech/renchan-job-bullmq'
+
+import SampleJobEngine from '../../SampleJobEngine.js'
+import BetaJobManifest from './BetaJobManifest.js'
+
+export default class BetaCronJobScheduler extends BaseCronJobScheduler {
+  static get EngineCtor () {
+    return SampleJobEngine
+  }
+
+  static get ManifestCtor () {
+    return BetaJobManifest
+  }
+
+  static get schedulerId () {
+    return 'beta-cron-scheduler'
+  }
+}
+```
+
+```js
+// SampleJobSchedulerService.js
+import {
+  BaseJobSchedulerService,
+} from '@openreachtech/renchan-job-bullmq'
+
+export default class SampleJobSchedulerService extends BaseJobSchedulerService {
+  static async collectScheduleInputs () {
+    return [
+      {
+        schedulerId: 'beta-cron-scheduler',
+        schedule: {
+          cronExpression: '* * * * *',
+        },
+        body: {
+          taskId: 1001,
+          message: 'cron heartbeat',
+        },
+        optionHash: {},
+      },
+      {
+        schedulerId: 'gamma-interval-scheduler',
+        schedule: {
+          millisecond: 10000,
+          isImmediately: true,
+        },
+        body: {
+          batchId: 2001,
+          label: 'interval ping',
+        },
+        optionHash: {},
+      },
+    ]
+  }
+}
+```
+
+```js
+// start-schedule.js
+import SampleJobEngine from '../app/SampleJobEngine.js'
+import SampleJobSchedulerService from '../app/SampleJobSchedulerService.js'
+
+const service = await SampleJobSchedulerService.createAsync({
+  EngineCtor: SampleJobEngine,
+})
+
+await service.startAllSchedulers() // upserts the repeatable jobs
+// await service.stopAllSchedulers() // removes them
+```
+
+Abstract members that are not overridden throw `ConcreteMemberNotFoundJobError` with the missing member's name, so a mis-wired job fails loudly.
+
+## API
+
+Class members are written with the following notation.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+Members marked ⚠ are abstract — the consuming application must override them.
+
+### `BaseJobEngine`
+
+Per-process configuration and DI hub.
+
+- `.createAsync({ config })` / `.create()`
+- ⚠ `.get:config` (`{ workersPath, schedulersPath?, redisConfig }`), ⚠ `.get:ShareCtor`, ⚠ `.get:ContextCtor`, ⚠ `.get:standardErrorCodeHash`, ⚠ `.get:savingLogFilePath`
+- optional override: `.get:savingLogFilePathLookup`, `.get:LoggerCtor`
+- `#get:env`, `#get:NODE_ENV`, `#get:timber`, `#get:processClerk`, `#get:Error`
+
+### `BaseJobManifest`
+
+- ⚠ `.get:jobName`, ⚠ `.get:bodySchema`
+
+### `BaseJobWorker`
+
+- `.createAsync()`
+- ⚠ `.get:ManifestCtor`
+- ⚠ `#executeJob({ body, context, parcel })`, ⚠ `#onJobCompleted()`, ⚠ `#onJobFailed()`, ⚠ `#onJobProgress()`, ⚠ `#onWorkerError()`
+- optional override: `.get:BuddyDispatcherCtor`, `.get:errorCodeHash`, `.get:additionalConfig`, `.collectAdditionalDispatcherCtorHash()`
+- `#ensureLogger()`, `#get:timber`, `#get:env`, `#get:Error`
+
+### `BaseJobDispatcher`
+
+- `.createAsync({ engine })` / `.create()`
+- ⚠ `.get:EngineCtor`, ⚠ `.get:ManifestCtor`
+- `#dispatchJob({ body, optionHash, keepsConnection })` → `DispatcherResponse`
+- `#teardown()`
+
+### `BaseJobScheduler` / `BaseCronJobScheduler` / `BaseIntervalJobScheduler`
+
+- `.createAsync({ engine })`
+- ⚠ `.get:EngineCtor`, ⚠ `.get:ManifestCtor`, ⚠ `.get:schedulerId` (the `Cron` / `Interval` subclasses supply `.get:ScheduleCtor`)
+- `#startSchedule({ schedule, body, optionHash })` → `SchedulerStartResponse`
+- `#stopSchedule()` → `SchedulerStopResponse`, `#teardown()`
+
+### `BaseJobSchedulerService`
+
+- `.createAsync({ EngineCtor })`
+- ⚠ `.collectScheduleInputs()` → `Array<{ schedulerId, schedule, body, optionHash }>`
+- `#startAllSchedulers()`, `#stopAllSchedulers()`, `#startScheduler({ schedulerId })`, `#stopScheduler({ schedulerId })`, `#restartScheduler({ schedulerId })`
+
+### `JobWorkersDaemon`
+
+- `.createAsync({ EngineCtor })`
+- `#startDaemon()` → the started workers, `#shutdownDaemon()`
+
+### `BaseJobContext` / `BaseJobShare`
+
+No abstract members — subclasses may be empty. Extend to add per-execution or process-wide dependencies. `Context` exposes `#get:share`, `#get:config`, `#get:env`, `#get:NODE_ENV`, `#get:timber`, `#get:now`.
+
+### Response objects
+
+Returned from dispatch / schedule calls: `DispatcherResponse` (`#hasError()`, `#hasResponse()`, `#get:errorMessage`, `#createDispatchedAt()`), `DispatcherShutdownResponse`, `SchedulerStartResponse` (`#hasError()`, `#hasResponse()`, `#isAborted()`), `SchedulerStopResponse`, `SchedulerShutdownResponse`, plus `JobModel` and `WorkerParcel`.
+
+### Errors
+
+- `RenchanJobError` — base error carrying an `errorCode`; `.declareJobError({ code })` mints code-bound subclasses.
+- `ConcreteMemberNotFoundJobError` — thrown by an un-overridden abstract member (code `101.X000.001`).
+
+### Tools
+
+- `DeepBulkClassLoader` — recursively loads default-exported classes from a directory (how workers and schedulers are discovered).
+- `ProcessClerk` — attaches / detaches process signal handlers.
+- `Timber` — a `console` proxy that silences output when `NODE_ENV === 'production'`.
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/renchan-job-bullmq.git
+cd renchan-job-bullmq
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/renchan-kafka/README.md
+++ b/lib/docs/renchan-kafka/README.md
@@ -4,9 +4,38 @@ A lightweight Kafka consumer daemon toolkit built on top of kafkajs.
 
 This guide shows the minimum setup to run the package with a local Docker stack (MariaDB + Kafka + Debezium), implement two consumers with one engine, and start the daemon by script.
 
-## 1. Setup Docker environment
+## Installation
 
-### 1.1 Start services
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/renchan-kafka
+```
+
+When using GitHub Packages (the `@openreachtech` scope), the following two items are
+required:
+
+1. Add the registry to your project's `.npmrc`:
+
+   ```
+   @openreachtech:registry=https://npm.pkg.github.com
+   ```
+
+2. Authenticate with `npm login`:
+
+   ```sh
+   npm login --registry https://npm.pkg.github.com
+   ```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+The following walkthrough sets up a local environment, implements two consumers behind a single engine, and runs the consumer daemon end to end.
+
+### 1. Setup Docker environment
+
+#### 1.1 Start services
 
 Sample docker file, name it `docker-compose.development.yml`
 
@@ -20,7 +49,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
       MYSQL_DATABASE: demo_db
-    # Binlog（変更ログ）を有効化するための設定
+    # Settings to enable the binlog (change log)
     command:
       - --server-id=1
       - --log-bin=mariadb-bin
@@ -70,7 +99,7 @@ Run:
 docker compose -f docker-compose.development.yml up
 ```
 
-### 1.2 Create demo tables
+#### 1.2 Create demo tables
 
 ```bash
 docker exec -it mariadb_demo mysql -uroot -prootpassword -e '
@@ -87,16 +116,16 @@ CREATE TABLE user_amounts (
 '
 ```
 
-## 2. Implement minimum application (two consumers + one engine)
+### 2. Implement minimum application (two consumers + one engine)
 
-### 2.1 Install package
+#### 2.1 Install package
 
 ```bash
 npm install @openreachtech/renchan-kafka
 npm install @openreachtech/mentsu-rootpath
 ```
 
-### 2.2 Suggested structure
+#### 2.2 Suggested structure
 
 ```text
 your-app/
@@ -114,11 +143,11 @@ your-app/
   .env.development
 ```
 
-### 2.3 Add .env.example file
+#### 2.3 Add .env.example file
 
 Add an empty .env.example file to the root directory.
 
-### 2.4 Register Debezium connector
+#### 2.4 Register Debezium connector
 
 Create src/kafka/connectors/MariadbConnector.js
 
@@ -140,7 +169,7 @@ export default class MariadbConnector extends BaseConnector {
 }
 ```
 
-### 2.5 Consumer #1 (eachMessage)
+#### 2.5 Consumer #1 (eachMessage)
 
 Create src/kafka/consumers/eachMessageConsumers/UserEachMessageConsumer.js:
 
@@ -225,7 +254,7 @@ export default class UserEachMessageConsumer extends BaseEachMessageConsumer {
 }
 ```
 
-### 2.6 Consumer #2 (eachBatch)
+#### 2.6 Consumer #2 (eachBatch)
 
 Create src/kafka/consumers/eachBatchConsumers/UserAmountEachBatchConsumer.js:
 
@@ -308,7 +337,7 @@ export default class UserAmountEachBatchConsumer extends BaseEachBatchConsumer {
 }
 ```
 
-### 2.7 Single engine for both consumers
+#### 2.7 Single engine for both consumers
 
 Create src/kafka/engine/AppKafkaEngine.js:
 
@@ -358,9 +387,9 @@ export default class AppKafkaEngine extends BaseKafkaEngine {
 }
 ```
 
-## 3. Start application by script
+### 3. Start application by script
 
-### 3.1 Create connector
+#### 3.1 Create connector
 Create src/kafka/scripts/create-connector-client.js:
 
 ```js
@@ -404,7 +433,7 @@ Run:
 NODE_ENV=development node src/kafka/scripts/create-connector-client.js
 ```
 
-### 3.2 Run Daemon
+#### 3.2 Run Daemon
 Create src/kafka/scripts/run-kafka-daemon.js:
 
 ```js
@@ -439,7 +468,7 @@ NODE_ENV=development node ./src/kafka/scripts/run-kafka-daemon.js
 
 Keep this terminal to see the consumers log.
 
-## 4. Test
+### 4. Test
 
 Open new terminal and Produce CDC events by changing MariaDB data:
 
@@ -463,3 +492,91 @@ DELETE FROM user_amounts WHERE id = 999;
 ```
 
 You should see logs from both consumers for INSERT, UPDATE, and DELETE events.
+
+## API
+
+Class members are written with the following notation.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+### Daemon & Engine
+
+- **`KafkaConsumersDaemon`** — boots every consumer discovered by the engine and runs them until shutdown.
+  - `.createAsync()` — build a daemon for a given `EngineCtor`.
+  - `#startDaemon()` — start consuming and block until the process is stopped.
+- **`BaseKafkaEngine`** — declares the Kafka connection, where consumers live, and the shared DI classes. Extend it and override:
+  - `.get:config` — `kafkaOptionHash`, `consumersPath`, and `consumerOptionHash`.
+  - `.get:ShareCtor` — the `BaseKafkaShare` subclass shared across consumers.
+  - `.get:ContextCtor` — the `BaseKafkaContext` subclass built per consumer.
+  - `.get:standardErrorCodeHash` — error codes shared across the engine.
+- **`BaseKafkaShare`** — per-process container of shared singletons handed to every consumer.
+- **`BaseKafkaContext`** — per-consumer context built by the engine.
+
+### Consumers
+
+- **`BaseConsumer`** — the abstract base for all consumers.
+- **`BaseEachMessageConsumer`** — processes one message at a time. Extend it and override:
+  - `.get:config` — consumer options such as `groupId`.
+  - `.get:MessageDeserializerCtor` / `.get:MessageKeyCtor` / `.get:MessageValueCtor` / `.get:ConsumerParcelCtor` — the message-shaping classes.
+  - `.collectTopics()` — the topics this consumer subscribes to.
+  - `#onEachMessage()` — the per-message handler you implement.
+- **`BaseEachBatchConsumer`** — processes a batch of messages, with the same override surface as `BaseEachMessageConsumer`.
+- **`BatchMessageProgress`** — tracks per-batch processing progress.
+
+### Messages
+
+- **`ConsumerMessage`** — a single consumed message, exposing its deserialized key/value.
+- **Deserializers** — `BaseMessageDeserializer`, `JsonMessageDeserializer`, `BufferMessageDeserializer`.
+- **Values** — `BaseMessageValue`, `DebeziumMessageValue` (normalizes Debezium CDC payloads).
+- **Keys** — `BaseMessageKey`, `DebeziumMessageKey`.
+- **Parcels** — `BaseConsumerParcel`, `EachMessageConsumerParcel`, `EachBatchConsumerParcel`.
+
+### Connectors & client
+
+- **`BaseConnector`** (with `AbstractCoreConnector` / `AbstractWorkflowConnector`) — registers and manages Debezium connectors over the Kafka Connect REST API. Extend it and override:
+  - `.get:connectorName` — the connector name.
+  - `.buildConfig()` — the connector base configuration.
+  - `#createConnectorFromBodyConfig()` — create the connector from a body config.
+- **Client three-class structure** — `BaseKafkaLauncher`, `BaseKafkaPayload`, `BaseKafkaCapsule`, plus the request/response bodies (`KafkaRequestBody`, `KafkaRequestQuery`, `KafkaResponseBody`) and the concrete `CreateConnector*` / `PutConnectorConfig*` operations.
+
+### Errors
+
+- **`KafkaError`** — base error type for the package.
+- **`ConcreteMemberNotFoundKafkaError`** — thrown when a required concrete member is not implemented.
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/renchan-kafka.git
+cd renchan-kafka
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/renchan-replica-fragments/README.md
+++ b/lib/docs/renchan-replica-fragments/README.md
@@ -1,0 +1,126 @@
+# @openreachtech/renchan-replica-fragments
+
+An Elasticsearch index for records whose columns are defined at runtime — write a record as a list of typed columns, and search it with operators instead of hand-written Query DSL.
+
+## Table of contents
+
+- [Concept](#concept)
+- [Installation](#installation)
+- [Features](#features)
+- [API](#api)
+- [Contribution](#contribution)
+- [License](#license)
+- [Developer](#developer)
+- [Copyright](#copyright)
+
+## Concept
+
+A replica fragment is one record copied into Elasticsearch. Its columns are not known when
+the index is defined — each column arrives with an id and a type, so a single mapping has
+to serve every record.
+
+That is solved by grouping values into one nested field per type:
+
+| Column type | Nested field |
+| :-- | :-- |
+| `BOOLEAN` | `booleanColumns` |
+| `DATETIME` | `datetimeColumns` |
+| `DOUBLE` | `doubleColumns` |
+| `INTEGER` | `integerColumns` |
+| `KEYWORD` | `keywordColumns` |
+| `TEXT` | `textColumns` |
+
+Each nested entry carries its `columnId` alongside its value, so a query for "column 12
+equals `paid`" becomes a nested query matching both at once.
+
+Three families of classes cover the round trip:
+
+| Family | Responsibility |
+| :-- | :-- |
+| **Entries** | Turn one incoming column into the nested entries it belongs in. One class per column type, resolved from the type. |
+| **Predicates** | Turn one filter — a column, an operator, and an operand — into a nested Query DSL clause. One class per operator. |
+| **Builders** | Compose entries into a document source, and predicates into a search query or sort. |
+
+`BaseReplicaFragmentIndex` ties them together, extending `BaseIndex` from
+[`@openreachtech/renchan-elasticsearch`](https://github.com/openreachtech/renchan-elasticsearch).
+
+## Installation
+
+Requires Node.js 20.x (the version the CI builds against).
+
+This package is published to GitHub Packages under the `@openreachtech` scope. Before
+installing, the following two steps are required:
+
+1. Add the registry to your project's `.npmrc`:
+
+   ```
+   @openreachtech:registry=https://npm.pkg.github.com
+   ```
+
+2. Authenticate with `npm login`:
+
+   ```sh
+   npm login --registry https://npm.pkg.github.com
+   ```
+
+Then install:
+
+```sh
+npm install @openreachtech/renchan-replica-fragments
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Features
+
+### (1) Defining an Index
+
+Subclass `BaseReplicaFragmentIndex` to model one replica fragment index.
+
+[Defining an Index](https://github.com/openreachtech/renchan-replica-fragments/blob/main/docs/en/features/defining-an-index.md)
+
+### (2) Writing Documents
+
+Put and upsert documents from column sources, without composing the nested source by hand.
+
+[Writing Documents](https://github.com/openreachtech/renchan-replica-fragments/blob/main/docs/en/features/writing-documents.md)
+
+### (3) Searching Documents
+
+Search with filters and operators, and order results by column.
+
+[Searching Documents](https://github.com/openreachtech/renchan-replica-fragments/blob/main/docs/en/features/searching-documents.md)
+
+## API
+
+See the API reference for the classes you extend and the members they expose.
+
+[API reference](https://github.com/openreachtech/renchan-replica-fragments/blob/main/docs/en/api/index.md)
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/renchan-replica-fragments.git
+cd renchan-replica-fragments
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/renchan-sequelize/README.md
+++ b/lib/docs/renchan-sequelize/README.md
@@ -1,11 +1,186 @@
 # Renchan Sequelize
 
+A Renchan facade over Sequelize that layers reusable models, mixins, and tooling
+on top of Sequelize's complex model definitions.
+
 ## Overview
 
-* Renchan module for Facade as Sequelize complex models.
+`@openreachtech/renchan-sequelize` centralizes the boilerplate of a Sequelize
+setup — activating a client, loading models, building `include` options, and
+generating subqueries — and exposes a family of base models and mixin models so
+that features such as pagination, backup history, referral trees, and versioned
+suites can be composed into a model without rewriting them each time.
 
-### Install
+## Installation
 
-```console
-% npm install @openreachtech/renchan-sequelize
+Requires Node.js 20.x (the version the CI builds against).
+
+```sh
+npm install @openreachtech/renchan-sequelize
 ```
+
+When using GitHub Packages (the `@openreachtech` scope), the following two items are
+required:
+
+1. Add the registry to your project's `.npmrc`:
+
+   ```
+   @openreachtech:registry=https://npm.pkg.github.com
+   ```
+
+2. Authenticate with `npm login`:
+
+   ```sh
+   npm login --registry https://npm.pkg.github.com
+   ```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+
+## Usage
+
+Define a model by extending `RenchanModel` and declaring its attributes with
+`ModelAttributeFactory`:
+
+```javascript
+import {
+  RenchanModel,
+  ModelAttributeFactory,
+} from '@openreachtech/renchan-sequelize'
+
+export default class UserModel extends RenchanModel {
+  /** @override */
+  static createAttributes (DataTypes) {
+    const attributeFactory = ModelAttributeFactory.create(DataTypes)
+
+    return {
+      ...attributeFactory.ID_BIGINT,
+
+      username: {
+        type: DataTypes.STRING(191),
+        allowNull: false,
+      },
+    }
+  }
+}
+```
+
+Compose reusable behavior by extending a mixin model — for example, add
+pagination to a query result:
+
+```javascript
+import {
+  PaginationMixinModel,
+} from '@openreachtech/renchan-sequelize'
+
+export default class PaymentModel extends PaginationMixinModel {
+  // ...
+}
+
+const responsePagination = await PaymentModel.findAllWithPagination({
+  // ...
+})
+```
+
+## API
+
+Class members are written with the following notation.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+The package exposes the following classes, grouped by role.
+
+### Models
+
+| Class | Description |
+| :-- | :-- |
+| `BaseRenchanModel` | Base Sequelize model that provides the shared query facade (attribute helpers, transactions, quoting). |
+| `RenchanModel` | Abstract model extending `BaseRenchanModel`, the standard base for application models. |
+| `FertileForestModel` | `RenchanModel` wired to the fertile-forest algorithm for hierarchical (tree) data. |
+
+### Mixin models
+
+| Class | Description |
+| :-- | :-- |
+| `BaseMixinModel` | Base class for mixin models, defining the mixin-target composition points. |
+| `AttributesLinearizerMixinModel` | Flattens nested attribute nodes into a linear set of attributes. |
+| `BackupMixinModel` | Mirrors saves and destroys into a backup table to retain history. |
+| `LatestStatusMixinModel` | Resolves and includes the latest status of an entity. |
+| `PaginationMixinModel` | Adds pagination scopes and `findAllWithPagination` support. |
+| `ReferralMixinModel` | Manages invite codes and referral-tree nodes. |
+| `SuiteVersionMixinModel` | Builds and finds versioned suites of related records. |
+
+### Hook payloads
+
+| Class | Description |
+| :-- | :-- |
+| `BaseHookPayload` | Base payload passed through model lifecycle hooks. |
+| `ReferralMixinHookPayload` | Hook payload for `ReferralMixinModel` operations. |
+
+### Request / response tools
+
+| Class | Description |
+| :-- | :-- |
+| `RequestPagination` | Normalizes an incoming pagination request (limit / offset). |
+| `RequestSort` | Normalizes an incoming sort request. |
+| `ResponsePagination` | Builds the pagination metadata returned in a response. |
+
+### Sequelize infrastructure
+
+| Class | Description |
+| :-- | :-- |
+| `SequelizeActivator` | Activates Sequelize: resolves config, generates a client, and loads models. |
+| `SequelizeClientGenerator` | Generates a configured Sequelize client instance. |
+| `SequelizeConfigResolver` | Resolves the Sequelize configuration for the current environment. |
+| `RenchanModelsLoader` | Loads and registers Renchan model classes from a directory. |
+
+### Tools
+
+| Class | Description |
+| :-- | :-- |
+| `ModelAttributeFactory` | Produces common Sequelize attribute definitions (e.g. `ID_BIGINT`). |
+| `MigrationAttributeFactory` | Produces common attribute definitions for migrations. |
+| `TimestampSeedsSupplier` | Supplies timestamp fields for seed records. |
+| `SubqueryGenerator` | Generates named subqueries for models. |
+| `SubqueryRegExpBuilder` | Builds the regular expressions that match subquery names. |
+| `WhereClauseExtractor` | Extracts a `where` clause from query parameters. |
+| `IncludeOptionBuilder` | Builds Sequelize `include` options from a node tree. |
+| `IncludeOptionNode` | A single node in the `include` option tree. |
+| `DeepBulkClassLoader` | Recursively loads classes from a directory tree. |
+| `RootPath` | Resolves the application root path. |
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/renchan-sequelize.git
+cd renchan-sequelize
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/lib/docs/renchan/README.md
+++ b/lib/docs/renchan/README.md
@@ -10,18 +10,8 @@ Node.js is required. If you haven't installed it yet, please do so first.
 
 | Tool | Version |
 | :-- | :-- |
-| Node.js | ^20.19.2 |
+| Node.js | >=20.0.0 |
 | npm | ^10.9.0 |
-
-## Setting up `.npmrc`
-
-Create a `.npmrc` file in your project's root directory and add the necessary configuration.
-
-Add the following line to your `.npmrc` file:
-
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
 
 ## Command
 
@@ -166,9 +156,9 @@ builder.buildHttpServer()
 
 ## License
 
-This project is released under the MIT License.
+This project is released under the Apache License 2.0.
 
-See [LICENSE](./LICENSE) for details.
+For more details, please see [in the LICENSE file](./LICENSE).
 
 ## Contributing
 
@@ -186,7 +176,7 @@ npm test
 
 ## Developers
 
-[Open Reach Tech inc.](https://openreach.tech)
+[Open Reach Tech Inc.](https://openreach.tech)
 
 ## Copyright
 


### PR DESCRIPTION
# Why

* Close #60

# How
* Using `/scribe` to collect the documents of all packages
* Collects every `README.md` again from the packages installed at the versions this repository now pins — 28 files: 16 that had drifted from what their package ships, and 12 that had no collected README at all
* The seven packages released today account for the visible part: their READMEs no longer tell a consumer to add the GitHub Packages registry, and `lib/docs/` was still handing that instruction to Hora
* **`API.md` is left untouched.** For the eight packages this release line bumped, I compared the published tarballs of the old and the new version file by file: the seven `mentsu-*` / `renchan-env` ones ship byte-identical code, and `furo-nuxt` changed only inside components and contexts, adding and removing no member. Nothing an `API.md` states has changed
* **Eleven collected documents still carry the GitHub Packages step, because the packages themselves still do**: `jest-constructor-spy`, `mentsu-mixin-builder`, `mentsu-rocket-client`, `mentsu-schema`, `mentsu-text-case-tools`, `renchan-elasticsearch`, `renchan-funnel`, `renchan-job-bullmq`, `renchan-kafka`, `renchan-replica-fragments` and `renchan-sequelize`. Each is a release of its own upstream, and this repository must not edit what it collects
