### PR TITLE
📦️ Update the package version to `0.0.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/hora-ecosystem",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/hora-ecosystem",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openreachtech/eslint-config": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/hora-ecosystem",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Module catalog of Hora Kit ecosystem",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
# Why

* Close #61

# How

* Raises the version from `0.0.0` to `0.0.1`, the version of this release line, in `package.json` and in the lock`s root entry
* Everything this line carries is in: the dependency versions, the release-age exclusion, and the documents collected again from the packages installed at those versions
