### PR TITLE
📦️ Fix `npm audit`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,9 +1963,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13000,9 +13000,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
# Why

* Close #49

# How

* `npm audit fix --package-lock-only` raises the two locked `js-yaml` copies — `3.15.0` to `3.15.1` and `4.3.0` to `4.3.1` — past GHSA-5p4m-2wfm-xmqj, the one high-severity advisory here. Both arrive through `jest` / `@istanbuljs/load-nyc-config`, so only the lock moves and no declared range changes
* **The four moderate ones are left, and cannot be closed here.** They are `uuid` below `11.1.1` reached through `sequelize`, which `@openreachtech/renchan` and `@openreachtech/renchan-funnel` depend on. npm reports `No fix available`: it waits on `sequelize` inside those packages, so nothing in this repository resolves it
* Audit after this change: `4 moderate severity vulnerabilities`, down from 5 with the high one gone
